### PR TITLE
Chore/uris to strings

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -56,3 +56,5 @@ toAddress
 utf-8
 ActivityPub
 Braxton
+Alexa
+prosumer

--- a/pages/Archivists/Format.md
+++ b/pages/Archivists/Format.md
@@ -58,7 +58,7 @@ A _Batch_ is data that is referenced by a Batch Announcement. It consists of one
 | `logIndex` | the index within the logs of this message | number |
 | `signature` | announcer's signature | Signature |
 | `transactionIndex` | the index of the transaction this message is associated with | number |
-| `uri` | the location of this archive | bytes |
+| `uri` | the location of this archive | string |
 
 
 ### `archives`
@@ -93,7 +93,7 @@ the social identity of the batch announcer, i.e. the message sender.
 * The transaction index in which this DSNP Message is included
 
 ### `uri`
-* bytes
+* string
 * The permanent URI address where this archive is stored.
 
 ## Signature

--- a/pages/Archivists/Format.md
+++ b/pages/Archivists/Format.md
@@ -10,7 +10,7 @@ menu: Archivists
 
 | Version | Status |
 ---------- | ---------
-| 0.1     | Tentative |
+| 0.2     | Draft |
 
 ## Purpose
 1. Specify the off-chain Archivist _storage_ format

--- a/pages/Implementation_Status.md
+++ b/pages/Implementation_Status.md
@@ -16,5 +16,5 @@ Component | Description                                                | Status
 ----------|------------------------------------------------------------|--------
 Identity  | Specification regarding the representation of users        | Draft
 Graph     | Specification regarding relationships between users        | Draft
-Messages  | Specification regarding content posted on the protocol     | Tentative
-Archives  | Specification regarding long term storage of data          | Tentative
+Messages  | Specification regarding content posted on the protocol     | Draft
+Archives  | Specification regarding long term storage of data          | Draft

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -10,7 +10,7 @@ menu: Messages
 
 | Version | Status |
 ---------- | ---------
-| 0.1     | Tentative |
+| 0.2     | Draft |
 
 ## Purpose
 1. Describe the form and content of DSNP Messages posted to the blockchain used for all Liberty Platform activities. Only some of these activities will have the full message posted to chain. Examples:
@@ -70,7 +70,7 @@ a public post (was Announcement)
 | ------------- |------------- | ---- |
 | fromAddress | ID of the sender | bytes20
 | messageID | keccak-256 hash of content stored at URI |  bytes32
-| uri       | content URI | bytes[]
+| uri       | content URI | string
 
 
 #### Reply
@@ -81,7 +81,7 @@ a public reply post
 | inReplyTo | ID of the message the reply references |  bytes32
 | messageID | keccak-256 hash of content stored at uri |  bytes32
 | fromAddress | ID of the sender | bytes20
-| uri       | content uri | bytes[]
+| uri       | content uri | string
 
 
 #### Drop
@@ -90,7 +90,7 @@ a dead drop message
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
 | deadDropID | The Dead Drop ID (See [DeadDrops](TBD) | bytes32
-| uri  | content uri  |  bytes[]
+| uri  | content uri  |  string
 | messageID | keccak-256 hash of content |  bytes32
 
 #### GraphChange
@@ -118,7 +118,7 @@ a direct message
 | toAddress | ID of the recipient | bytes20
 | fromAddress | id of the sender | bytes20
 | messageID | keccak-256 hash of content | bytes32
-| uri  | content uri  | bytes[]
+| uri  | content uri  | string
 
 #### EncryptedInbox
 an encrypted direct message.
@@ -130,7 +130,7 @@ Possibly combine both of these and expect that all Inbox messages are encrypted.
 | toAddress | ID of the recipient | bytes20
 | fromAddress | ID of the sender | bytes20
 | messageID | keccak-256 hash of content | bytes32
-| uri  | content uri  | bytes[]
+| uri  | content uri  | string
 
 #### Reaction
 a visual reply to a post
@@ -149,7 +149,7 @@ a profile update such as name or icon change
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
 | fromAddress | id of the sender | bytes20
-| uri    | uri for the profile data  |bytes[]
+| uri    | uri for the profile data  |string
 | messageID |  keccak-256 hash of content at uri | bytes32
 
 #### Private
@@ -159,7 +159,7 @@ See [DSNP Message Types: Private Messages](/DSNP/DSNP-Message-Types#private-mess
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
 | fromAddress | id of the sender | bytes20
-| data | encrypted graph change data | bytes[]
+| data | encrypted graph change data | string
 | messageID | keccak-256 hash of unencrypted content | bytes32
 
 #### PrivateBroadcast
@@ -171,7 +171,7 @@ This describes the format once decrypted.
 | fromAddress | id of the sender | bytes20
 | inReplyTo | ID of the message the broadcast references |  bytes32
 | messageID      | keccak-256 hash of content stored at URI |  bytes32
-| uri       | content uri | bytes[]
+| uri       | content uri | string
 
 
 ### Unified Message Format
@@ -195,7 +195,7 @@ This is currently not the recommended solution, but is presented as a comparison
 | topic | Ethereum log topic |  bytes
 | action type | the type of action | bytes
 | fromAddress | social identity | bytes
-| uri | uri of stored action information | bytes
+| uri | uri of stored action information | string
 
 ### All data on chain
 One possibility is not to have any data stored off-chain; instead, even the ActivityPub content would be posted to chain.


### PR DESCRIPTION
Problem
=======
So that the spec will match what we are planning for contracts in Ethereum/Solidty, update URIs in the spec to be type `string`
[Fixes #177208548](https://www.pivotaltracker.com/story/show/177208548)

Solution
========
Update field type bytes to string anywhere there is a  URI.  I changed it in Archive Messages too just for ease of conversion.

with @pairperson1

Change summary:
---------------
* Changed bytes --> string in Archive Messages and DSNP Messages
* Bumped version
* Updated Status according to process.

Steps to Verify:
----------------
Please make sure I didn't miss any places where a URI field should be a string.
