### PR TITLE
fix slack description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "liberty-protocol-spec",
     "version": "0.0.1",
     "private": true,
+    "description": "Detailed documentation regarding the current state of the protocol",
     "files": [
         "src/",
         "pages/",


### PR DESCRIPTION
Problem
=======
when link sent through slack, it showed the default description, "My awesome app using doz".  We want it to say a correct description of the spec.
[link to Pivotal Tracker #177255014](https://www.pivotaltracker.com/story/show/177255014)

Solution
========
added new description

with @Ajaxan @rosalinekarr 

Change summary:
---------------
* added description to the package.json to override the default description
* now says "Detailed documentation regarding the current state of the protocol"

Steps to Verify:
----------------
1. send the link (https://libertydsnp.github.io/spec/) when merged through slack
2. check that the part described in the screenshot below no longer reads as "My awesome app using doz"
<img width="348" alt="Screen Shot 2021-03-08 at 2 10 58 PM" src="https://user-images.githubusercontent.com/43625033/110388568-1da73580-8018-11eb-81b0-b10c7af2cf3d.png">


