### PR TITLE
[#176782729] Add CNAME file to inform github where to host the spec site

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+spec.projectliberty.io


### PR DESCRIPTION
Problem
=======

Host the spec on a friendly URL, spec.projectliberty.io
[link to Pivotal Tracker #12345678](https://www.pivotaltracker.com/story/show/12345678)

Solution
========
Add CNAME file to top level of the repo with the desired hostname.    spec.projectliberty.io.     DNS will still need to be updated to set a CNAME for spec to projectliberty.github.io 

Steps to Verify:
----------------
1. Merge to gh-pages
1. Add CNAME to projectliberty.io DNS
1. Test that the site loads at spec.projectliberty.io


