### PR TITLE
Fix links and make links match filenames

### DIFF
--- a/pages/Archivists/Format.md
+++ b/pages/Archivists/Format.md
@@ -30,8 +30,8 @@ It is a key-value map consisting of the following fields:
 
 | field name | description |type |
 | --- | --- | --- |
-| `dsnpType` | DSNP message type |number/enum. see [DSNP Message Types](/DSNP/DSNP-Message-Types) |
-| `dsnpData` | DSNP message data | see fields in [DSNP Messages](/DSNP/DSNP-Messages) |
+| `dsnpType` | DSNP message type |number/enum. see [DSNP Message Types](/Messages/Types) |
+| `dsnpData` | DSNP message data | see fields in [DSNP Messages](/Messages/Overview) |
 | `signatures` | list of signatures for this message | array of Signatures |
 
 ### `dsnpType`
@@ -40,7 +40,7 @@ It is a key-value map consisting of the following fields:
 
 ### `dsnpData`
 * varies
-* This can be encrypted, and/or serialized, and compressed where feasible.  The decrypted, fully deserialized version must be one of the types described in [DSNP Messages](/DSNP/DSNP-Messages).
+* This can be encrypted, and/or serialized, and compressed where feasible.  The decrypted, fully deserialized version must be one of the types described in [DSNP Messages](/Messages/Overview).
 
 ### `signatures`
 * array

--- a/pages/Implementation_Status.md
+++ b/pages/Implementation_Status.md
@@ -1,6 +1,6 @@
 ---
 name: Implementation Status
-route: /implementation_status
+route: /Implementation_Status
 ---
 
 # Implementation Status

--- a/pages/Messages/Announce.md
+++ b/pages/Messages/Announce.md
@@ -12,7 +12,7 @@ menu: Messages
 | 0.1     | Tentative |
 
 ## Purpose
-1. Describe the method to announce [DSNP Messages](/DSNP/Overview) to the blockchain.
+1. Describe the method to announce [DSNP Messages](/Messages/Overview) to the blockchain.
 1. Provide Solidity code examples (pending final contract)
 1. Facilitate use of SDK and locating of on-chain data
 
@@ -27,7 +27,7 @@ menu: Messages
 
 ### DSNPBatch Event
 
-The DSNPBatch event is a standard event topic to be used for announcing a location that a list of [DSNP Messages](/DSNP/DSNP-Messages) can be found.
+The DSNPBatch event is a standard event topic to be used for announcing a location that a list of [DSNP Messages](/Messages/Overview) can be found.
 
 ```solidity
 interface IAnnounce {
@@ -38,7 +38,7 @@ interface IAnnounce {
 | field | description | type |
 |-------|-------------|------|
 | dsnpHash | Keccak-256 hash of each hash included in the batch | bytes32 |
-| dsnpUri | Uri containing the batch file matching [DSNP Messages](/DSNP/Overview) | string |
+| dsnpUri | Uri containing the batch file matching [DSNP Messages](/Messages/Overview) | string |
 
 
 ### Event Topic

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -61,7 +61,7 @@ This is what would be posted as a Log event in Ethereum:
 ### DSNP Messages
 These messages would be serialized, compressed where feasible, and emitted in the log event as the `DSNPData` field.
 
-For details on how messages are serialized, see [DSNP Message Serialization](/DSNP/DSNP-Message-Serialization)
+For details on how messages are serialized, see [DSNP Message Serialization](/Messages/Serialization)
 
 #### Broadcast
 a public post (was Announcement)
@@ -154,7 +154,7 @@ a profile update such as name or icon change
 
 #### Private
 An encrypted message of unknown type.
-See [DSNP Message Types: Private Messages](/DSNP/DSNP-Message-Types#private-messages) for details.
+See [DSNP Message Types: Private Messages](/Messages/Types#private-messages) for details.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |

--- a/pages/Messages/Serialization.md
+++ b/pages/Messages/Serialization.md
@@ -17,7 +17,7 @@ menu: Messages
 1. Facilitate use of SDK
 
 ## Assumptions
-* All assumptions from [DSNP Messages](/DSNP/DSNP-Messages)
+* All assumptions from [DSNP Messages](/Messages/Overview)
 * Content may be compressed where feasible
 * Serialization is in JSON (highly subject to change)
 

--- a/pages/Messages/Types.md
+++ b/pages/Messages/Types.md
@@ -13,14 +13,14 @@ menu: Messages
 | 0.1     | Tentative |
 
 ## Purpose
-1. List valid message types and their [DSNP Message](/DSNP/DSNP-Messages) type assigned enumeration
+1. List valid message types and their [DSNP Message](/Messages/Overview) type assigned enumeration
 1. Facilitate use of SDK
 1. Facilitate interpretation of on-chain data and message results
 1. Estimate data size
 
 
 ## Assumptions
-* All assumptions from [DSNP Messages](/DSNP/DSNP-Messages)
+* All assumptions from [DSNP Messages](/Messages/Overview)
 * Message types are preset, but the DSNP Message contract will be upgradeable to allow more types.
 * Message type values outside the contract presets are invalid
 
@@ -44,4 +44,4 @@ If it's not desired to specify a message type, use the `Private` value as the me
 
 Note that a Drop, i.e. a dead drop message cannot be made private with this message, since the dead drop ID, which is a necessary shared secret for decryption, would not be available.
 
-See [DSNP Message Serialization](/DSNP/DSNP-Message-Serialization) for more detail
+See [DSNP Message Serialization](/Messages/Serialization) for more detail

--- a/pages/index.md
+++ b/pages/index.md
@@ -33,7 +33,7 @@ The specification is divided into several modules found in the DSNP section of t
 Each module describes a self-contained aspect of the DSNP and includes documents detailing the function and intended use the module.
 Generally, each of these documents will include sections on the purpose of the module, assumptions made in the document and the current status of the specification.
 
-Additionally, the status of each module is also compiled in the [Implementation Status](/DSNP/Implementation_Status) table for ease of access.
+Additionally, the status of each module is also compiled in the [Implementation Status](/Implementation_Status) table for ease of access.
 As further extensions of the protocol are created, more modules may be added to the DSNP directory and status table.
 Proposals for some of these future extensions can be found in the Future Proposals directory under DSNP, however these proposals should be regarded with caution as they are largely incomplete and may be subject to change or deletion without notice.
 


### PR DESCRIPTION
Problem
=======
problem statement, including
[link to Pivotal Tracker #177439791](https://www.pivotaltracker.com/story/show/177439791)

Solution
========
Updated links to make sure they all worked.

Change summary:
---------------
* Updated broken links
* Updated link for /implementation_status to /Implementation_Status as github pages is case sensitive and now case matches filenames

Steps to Verify:
----------------
1. Run a local instance
1. Check internal links
