### PR TITLE
Looks like this package doesn't use relative URLs so links broke when…

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,5 +1,5 @@
 export default {
-  base: "/spec/",
+  base: "/",
   typescript: true,
   ignore: ["CODEOFCONDUCT.md", "LICENSE.md", "README.md"],
   menu: [


### PR DESCRIPTION
… the

site moved from libertydsnp.github.org/spec -> spec.projectliberty.io as
they all had the /spec prefix.    Change the base from /spec/ to /

Problem
=======

Links are broken on the new spec.projectliberty.io site due to /spec/ being prefixed on the links.

[l#177448146](https://www.pivotaltracker.com/story/show/177448146)

Solution
========
Change the base URL from /spec/ to /   I don't know this doc package at all so just guessing that the base url in doczrc.js is what is causing the issue.   When run in dev mode it works fine.


Steps to Verify:
----------------
Check that the links are working and no longer have /spec/ prefixed




