### PR TITLE
Features/clarify message naming 177909992

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -97,3 +97,6 @@ roadmap
 NodeJS
 Lookups
 ICANN
+contentHash
+W3C
+Mastadon

--- a/.spelling
+++ b/.spelling
@@ -99,4 +99,4 @@ Lookups
 ICANN
 contentHash
 W3C
-Mastadon
+Mastodon

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -10,7 +10,7 @@ menu: Messages
 
 | Version | Status |
 ---------- | ---------
-| 0.2     | Tentative |
+| 0.3     | Tentative |
 
 ## Purpose
 
@@ -44,7 +44,6 @@ Some announcements, such as broadcasts and replies, will contain references to c
 
 Content items, or simply content, refers to an activity pub compliant object hosted at some URI and intended to be posted via an announcement in a batch.
 Generally, content within the DSNP specification will be defined by the [W3C Activity Pub specification](https://www.w3.org/TR/activitypub/#object-without-create), however extensions, such as the [Mastadon Activity Pub specification](https://docs.joinmastodon.org/spec/activitypub/) may also be implemented.
-This specification will not directly define any standards for content.
 
 #### Message
 

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -13,6 +13,7 @@ menu: Messages
 | 0.2     | Tentative |
 
 ## Purpose
+
 1. Describe the form and content of DSNP Messages posted to the blockchain used for all Liberty Platform activities. Only some of these activities will have the full message posted to chain. Examples:
     * Public messages (profile changes, public posts, reactions)
     * Direct messages between accounts (dead drop, inbox)
@@ -23,16 +24,19 @@ menu: Messages
 1. Facilitate use of SDK and interpretation of on-chain data
 
 ## Assumptions
+
 * Announcements are on Ethereum.
 * Announcement data is posted via [Ethereum log events](https://medium.com/mycrypto/understanding-event-logs-on-the-ethereum-blockchain-f4ae7ba50378).
 * Signature algorithm is [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). This allows the use of `ecreover` to get public keys. A public key also need not be included in a log event for ease of validation.
 * Content hashes are created via the same [keccak-256 hashing algorithm](https://en.wikipedia.org/wiki/SHA-3) used by Ethereum.
 
 ## DSNP Announcement Formats
+
 We have seriously considered two possibilities, a [variable announcement format](#Variable-Announcement-Format), and a [unified announcement format](#unified-announcement-format).
 Others are listed at the end of this page.
 
 ### Variable Announcement Format
+
 This format is the current preference.
 
 * All actions are posted to chain with some or all pertinent information about the action
@@ -55,16 +59,19 @@ This is what would be posted as a Log event in Ethereum:
 | dsnpData | serialized, possibly compressed message data| bytes |
 
 #### Some other options:
+
 * Emit no topic, have a single contract that subscribers watch for events from.  Subscribers can perform filtering based on the `dsnpTopic` field.
 * The topic is the dsnpType (possibly not an enum).  Subscribers could listen for desired topics.
 
 ### DSNP Announcement
+
 These announcements would be serialized, compressed where feasible, and emitted in the log event as the `DSNPData` field.
 
 For details on how messages are serialized, see [DSNP Message Serialization](/Messages/Serialization)
 
 #### Broadcast
-a public post
+
+A public post.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -74,7 +81,8 @@ a public post
 
 
 #### Reply
-a public reply post
+
+A public reply post.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -85,7 +93,8 @@ a public reply post
 
 
 #### Drop
-a dead drop message
+
+A dead drop message.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -94,7 +103,8 @@ a dead drop message
 | contentHash | keccak-256 hash of content |  bytes32
 
 #### GraphChange
-a public follow/unfollow
+
+A public follow/unfollow.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -103,7 +113,7 @@ a public follow/unfollow
 
 #### KeyList, PrivateGraphKeyList, EncryptionKeyList
 
-a KeyList rotation
+A KeyList rotation.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -111,7 +121,8 @@ a KeyList rotation
 | keyList | new list of valid keys | bytes[]
 
 #### Inbox
-a direct message
+
+A direct message.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -121,7 +132,8 @@ a direct message
 | uri  | content uri  | string
 
 #### EncryptedInbox
-an encrypted direct message.
+
+An encrypted direct message.
 This describes the format once decrypted.
 Possibly combine both of these and expect that all Inbox messages are encrypted.
 
@@ -133,7 +145,8 @@ Possibly combine both of these and expect that all Inbox messages are encrypted.
 | uri  | content uri  | string
 
 #### Reaction
-a visual reply to a post
+
+A visual reply to a post.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -144,7 +157,8 @@ a visual reply to a post
 ### Possible Announcement Types
 
 #### Profile
-a profile update such as name or icon change
+
+A profile update such as name or icon change.
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -153,6 +167,7 @@ a profile update such as name or icon change
 | contentHash |  keccak-256 hash of content at uri | bytes32
 
 #### Private
+
 An encrypted message of unknown type.
 See [DSNP Message Types: Private Messages](/Messages/Types#private-messages) for details.
 
@@ -163,6 +178,7 @@ See [DSNP Message Types: Private Messages](/Messages/Types#private-messages) for
 | contentHash | keccak-256 hash of unencrypted content | bytes32
 
 #### PrivateBroadcast
+
 An encrypted Broadcast decipherable by specific accounts.
 This describes the format once decrypted.
 
@@ -175,6 +191,7 @@ This describes the format once decrypted.
 
 
 ### Unified Announcement Format
+
 This is currently not the recommended solution, but is presented as a comparison.
 
 * All actions are posted to the chain with some pertinent information about the action
@@ -198,6 +215,7 @@ This is currently not the recommended solution, but is presented as a comparison
 | uri | uri of stored action information | string
 
 ### All data on chain
+
 One possibility is not to have any data stored off-chain; instead, even the ActivityPub content would be posted to chain.
 The disadvantages far outweigh the advantages:
 
@@ -211,4 +229,5 @@ The disadvantages far outweigh the advantages:
     * Unknown, likely chilling effect on incentive models
 
 ### No data except hashes on chain
+
 Only hashes of the events are stored on chain; everything else is interpreted via API(s)

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -18,21 +18,21 @@ menu: Messages
     * Direct messages between accounts (dead drop, inbox)
     * Key changes (private graph KeyList, encryption KeyList, public key rotation)
     * Graph changes (follow/unfollow)
-1. Specify an on-chain message format
+1. Specify an on-chain announcement format
 1. Provide data size estimations
 1. Facilitate use of SDK and interpretation of on-chain data
 
 ## Assumptions
-* Chain messages are on Ethereum
-* Message data is posted via [Ethereum log events](https://medium.com/mycrypto/understanding-event-logs-on-the-ethereum-blockchain-f4ae7ba50378)
-* Signature algorithm is [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). This allows the use of `ecreover`
-  to get public keys. A public key also need not be included in a log event for ease of validation.
-* content hashes are created via the same [keccak-256 hashing algorithm](https://en.wikipedia.org/wiki/SHA-3) used by Ethereum.
+* Announcements are on Ethereum.
+* Announcement data is posted via [Ethereum log events](https://medium.com/mycrypto/understanding-event-logs-on-the-ethereum-blockchain-f4ae7ba50378).
+* Signature algorithm is [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). This allows the use of `ecreover` to get public keys. A public key also need not be included in a log event for ease of validation.
+* Content hashes are created via the same [keccak-256 hashing algorithm](https://en.wikipedia.org/wiki/SHA-3) used by Ethereum.
 
-## DSNP Message Formats
-We have seriously considered two possibilities, a [variable message format](#Variable-Message-Format), and a [unified message format](#unified-message-format).  Others are listed at the end of this page.
+## DSNP Announcement Formats
+We have seriously considered two possibilities, a [variable announcement format](#Variable-Announcement-Format), and a [unified announcement format](#unified-announcement-format).
+Others are listed at the end of this page.
 
-### Variable Message Format
+### Variable Announcement Format
 This format is the current preference.
 
 * All actions are posted to chain with some or all pertinent information about the action
@@ -44,7 +44,7 @@ This format is the current preference.
 * **Disadvantages**
     * more data (likely more costly up front) than a simple URI
 
-**Log message format **
+#### Log Event Format
 
 This is what would be posted as a Log event in Ethereum:
 
@@ -58,13 +58,13 @@ This is what would be posted as a Log event in Ethereum:
 * Emit no topic, have a single contract that subscribers watch for events from.  Subscribers can perform filtering based on the `dsnpTopic` field.
 * The topic is the dsnpType (possibly not an enum).  Subscribers could listen for desired topics.
 
-### DSNP Messages
-These messages would be serialized, compressed where feasible, and emitted in the log event as the `DSNPData` field.
+### DSNP Announcement
+These announcements would be serialized, compressed where feasible, and emitted in the log event as the `DSNPData` field.
 
 For details on how messages are serialized, see [DSNP Message Serialization](/Messages/Serialization)
 
 #### Broadcast
-a public post (was Announcement)
+a public post
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
@@ -78,7 +78,7 @@ a public reply post
 
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
-| inReplyTo | ID of the message the reply references |  bytes32
+| inReplyTo | ID of the announcement the reply references |  bytes32
 | messageID | keccak-256 hash of content stored at uri |  bytes32
 | fromAddress | ID of the sender | bytes20
 | uri       | content uri | string
@@ -141,7 +141,7 @@ a visual reply to a post
 | fromAddress | id of the sender | bytes20
 | emoji | the encoded reaction  | number / UTF-8 bytes[]
 
-### Possible Message Types
+### Possible Announcement Types
 
 #### Profile
 a profile update such as name or icon change
@@ -174,7 +174,7 @@ This describes the format once decrypted.
 | uri       | content uri | string
 
 
-### Unified Message Format
+### Unified Announcement Format
 This is currently not the recommended solution, but is presented as a comparison.
 
 * All actions are posted to the chain with some pertinent information about the action

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -43,7 +43,7 @@ Some announcements, such as broadcasts and replies, will contain references to c
 #### Content
 
 Content items, or simply content, refers to an activity pub compliant object hosted at some URI and intended to be posted via an announcement in a batch.
-Generally, content within the DSNP specification will be defined by the [W3C Activity Pub specification](https://www.w3.org/TR/activitypub/#object-without-create), however extensions, such as the [Mastadon Activity Pub specification](https://docs.joinmastodon.org/spec/activitypub/) may also be implemented.
+Generally, content within the DSNP specification will be defined by the [W3C Activity Pub specification](https://www.w3.org/TR/activitypub/#object-without-create), however extensions, such as the [Mastodon Activity Pub specification](https://docs.joinmastodon.org/spec/activitypub/) may also be implemented.
 
 #### Message
 

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -55,7 +55,7 @@ In the case of other types of announcements, message may be used an alias for an
 #### Event
 
 Events refer specifically to log events on the Ethereum blockchain.
-To avoid confusion with other terms, we will not officially refer to announcements, content or messages as events, however they may be referred to as such unnofficially in more casual conversation such as forum posts, GitHub issues or pull requests.
+To avoid confusion with other terms, we will not officially refer to announcements, content or messages as events, however they may be referred to as such unofficially in more casual conversation such as forum posts, GitHub issues or pull requests.
 
 ## DSNP Announcement Formats
 

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -69,7 +69,7 @@ a public post
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
 | fromAddress | ID of the sender | bytes20
-| messageID | keccak-256 hash of content stored at URI |  bytes32
+| contentHash | keccak-256 hash of content stored at URI |  bytes32
 | uri       | content URI | string
 
 
@@ -79,7 +79,7 @@ a public reply post
 | dsnpData field | description | type |
 | ------------- |------------- | ---- |
 | inReplyTo | ID of the announcement the reply references |  bytes32
-| messageID | keccak-256 hash of content stored at uri |  bytes32
+| contentHash | keccak-256 hash of content stored at uri |  bytes32
 | fromAddress | ID of the sender | bytes20
 | uri       | content uri | string
 
@@ -91,7 +91,7 @@ a dead drop message
 | ------------- |------------- | ---- |
 | deadDropID | The Dead Drop ID (See [DeadDrops](TBD) | bytes32
 | uri  | content uri  |  string
-| messageID | keccak-256 hash of content |  bytes32
+| contentHash | keccak-256 hash of content |  bytes32
 
 #### GraphChange
 a public follow/unfollow
@@ -117,7 +117,7 @@ a direct message
 | ------------- |------------- | ---- |
 | toAddress | ID of the recipient | bytes20
 | fromAddress | id of the sender | bytes20
-| messageID | keccak-256 hash of content | bytes32
+| contentHash | keccak-256 hash of content | bytes32
 | uri  | content uri  | string
 
 #### EncryptedInbox
@@ -129,7 +129,7 @@ Possibly combine both of these and expect that all Inbox messages are encrypted.
 | ------------- |------------- | ---- |
 | toAddress | ID of the recipient | bytes20
 | fromAddress | ID of the sender | bytes20
-| messageID | keccak-256 hash of content | bytes32
+| contentHash | keccak-256 hash of content | bytes32
 | uri  | content uri  | string
 
 #### Reaction
@@ -150,7 +150,7 @@ a profile update such as name or icon change
 | ------------- |------------- | ---- |
 | fromAddress | id of the sender | bytes20
 | uri    | uri for the profile data  |string
-| messageID |  keccak-256 hash of content at uri | bytes32
+| contentHash |  keccak-256 hash of content at uri | bytes32
 
 #### Private
 An encrypted message of unknown type.
@@ -160,17 +160,17 @@ See [DSNP Message Types: Private Messages](/Messages/Types#private-messages) for
 | ------------- |------------- | ---- |
 | fromAddress | id of the sender | bytes20
 | data | encrypted graph change data | string
-| messageID | keccak-256 hash of unencrypted content | bytes32
+| contentHash | keccak-256 hash of unencrypted content | bytes32
 
 #### PrivateBroadcast
 An encrypted Broadcast decipherable by specific accounts.
 This describes the format once decrypted.
 
 | dsnpData field | description | type |
-| ------------- |------------- | ---- |
+| -------------- |------------ | ---- |
 | fromAddress | id of the sender | bytes20
 | inReplyTo | ID of the message the broadcast references |  bytes32
-| messageID      | keccak-256 hash of content stored at URI |  bytes32
+| contentHash      | keccak-256 hash of content stored at URI |  bytes32
 | uri       | content uri | string
 
 

--- a/pages/Messages/Overview.md
+++ b/pages/Messages/Overview.md
@@ -30,6 +30,33 @@ menu: Messages
 * Signature algorithm is [secp256k1](https://en.bitcoin.it/wiki/Secp256k1). This allows the use of `ecreover` to get public keys. A public key also need not be included in a log event for ease of validation.
 * Content hashes are created via the same [keccak-256 hashing algorithm](https://en.wikipedia.org/wiki/SHA-3) used by Ethereum.
 
+## Terminology
+
+In the interest of clarity, we will define the terms "message," "content," "announcement" and "event" as distinct but related objects going forward in this specification.
+
+#### Announcement
+
+An announcement refers specifically to a DSNP item as described in this specification document.
+An announcement is intended for inclusion in a batch file and to eventually be posted to the blockchain via a batch log event.
+Some announcements, such as broadcasts and replies, will contain references to content items.
+
+#### Content
+
+Content items, or simply content, refers to an activity pub compliant object hosted at some URI and intended to be posted via an announcement in a batch.
+Generally, content within the DSNP specification will be defined by the [W3C Activity Pub specification](https://www.w3.org/TR/activitypub/#object-without-create), however extensions, such as the [Mastadon Activity Pub specification](https://docs.joinmastodon.org/spec/activitypub/) may also be implemented.
+This specification will not directly define any standards for content.
+
+#### Message
+
+Messages refer more generally to a piece of information posted via the DSNP specification.
+In the case of broadcasts and replies, message may refer to the both the DSNP announcement of the content and the content itself.
+In the case of other types of announcements, message may be used an alias for announcements.
+
+#### Event
+
+Events refer specifically to log events on the Ethereum blockchain.
+To avoid confusion with other terms, we will not officially refer to announcements, content or messages as events, however they may be referred to as such unnofficially in more casual conversation such as forum posts, GitHub issues or pull requests.
+
 ## DSNP Announcement Formats
 
 We have seriously considered two possibilities, a [variable announcement format](#Variable-Announcement-Format), and a [unified announcement format](#unified-announcement-format).

--- a/pages/Messages/Serialization.md
+++ b/pages/Messages/Serialization.md
@@ -13,7 +13,7 @@ menu: Messages
 | 0.1     | Tentative |
 
 ## Purpose
-1. Describe the form and method of DSNP message serialization for posting messages in Ethereum logs.
+1. Describe the form and method of DSNP message serialization for posting announcements in Ethereum logs.
 1. Facilitate use of SDK
 
 ## Assumptions
@@ -34,7 +34,7 @@ During early development we are using plain JSON for serialization, however, thi
 ## Serializing Identifiable Messages
 Identifiable messages are those with a DSNP Message Type other than `Private`.  They may still be private messages, but it's known what _type_ of message it is.
 
-1. Serialize the message, as with this GraphChange, which is a follow of address `0x3c0ffee5`:
+1. Serialize the announcement, as with this GraphChange, which is a follow of address `0x3c0ffee5`:
     ```json
     {
         "address": "0x3c0ffee5",


### PR DESCRIPTION
Problem
=======
We use the terms "announcement," "message," "content," and "event" interchangeably for several different concepts which may be confusing for people reading the spec.
[#177909992](https://www.pivotaltracker.com/story/show/177909992)

Solution
========
Change our usage of these terms to be consistent and add a section to the message overview document to expand on their meanings.


