### PR TITLE
remove authorization from initial registration

### DIFF
--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -14,7 +14,7 @@ while maintaining all graph connections, public and private.
 
 | Version | Status |
 ---------- | ---------
-| 0.1     | Tentative |
+| 0.2     | Tentative |
 
 ## Purpose
 1. Describes how the Identity Registry resolves a DSNP Id to an identity contract address

--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -137,26 +137,10 @@ interface IRegistry {
      * @param handle The handle for discovery
      * 
      * MUST reject if the handle is already in use
-     * MUST be called by someone who is authorized on the contract
-     *      via `IDelegation(addr).isAuthorizedTo(msg.sender, Permission.OWNERSHIP_TRANSFER, block.number)`
      * MUST emit DSNPRegistryUpdate
+     * MUST confirm contract at address implements `IDelegation` via an EIP 165 `supportsInterface` call.
      */
     function register(address addr, string handle) external returns (uint64);
-
-    /**
-     * @dev Register a new DSNP Id by EIP-712 Signature
-     * @param r ECDSA Signature r value
-     * @param s ECDSA Signature s value
-     * @param v EIP-155 calculated Signature v value
-     * @param addr Address for the new DSNP Id to point at
-     * @param handle The handle for discovery
-     * 
-     * MUST reject if the handle is already in use 
-     * MUST be signed by someone who is authorized on the contract
-     *      via `IDelegation(addr).isAuthorizedTo(ecrecovedAddr, Permission.OWNERSHIP_TRANSFER, block.number)`
-     * MUST emit DSNPRegistryUpdate
-     */
-    function registerByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address addr, string handle) external returns (uint64);
 
     /**
      * @dev Alter a DSNP Id resolution address

--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -138,7 +138,7 @@ interface IRegistry {
      * 
      * MUST reject if the handle is already in use
      * MUST emit DSNPRegistryUpdate
-     * MUST confirm contract at address implements `IDelegation` via an EIP 165 `supportsInterface` call.
+     * MUST check that addr implements IDelegation interface
      */
     function register(address addr, string handle) external returns (uint64);
 
@@ -150,6 +150,7 @@ interface IRegistry {
      * MUST be called by someone who is authorized on the contract
      *      via `IDelegation(oldAddr).isAuthorizedTo(oldAddr, Permission.OWNERSHIP_TRANSFER, block.number)`
      * MUST emit DSNPRegistryUpdate
+     * MUST check that newAddr implements IDelegation interface
      */
     function changeAddress(address newAddr, string handle) external;
 


### PR DESCRIPTION
closes #33 

Problem
=======
Authorization for a new identity from its delegation contract isn't necessary. It can be circumvented by `changeAddress` if it does not authenticate against the new contract, and transferring between delegation contracts is complicated if it does. 
[link to Pivotal Tracker #178010820](https://www.pivotaltracker.com/story/show/178010820)

Solution
========
This PR replaces the requirement that `register` and `changeAddress` authorize against the contract with the requirement that it confirm the contract implements IDelegation. It also removes the `registerByEIP712Sig` since the `register` method now does the same thing and is more cost effective.

Change summary:
---------------
* Remove language about call to `IDelegation.isAuthorizedTo` in `register`.
* Add language about call to EIP 165 `supportsInterface` in `register`.
* Remove `registerByEIP712Sig` method.
* Add language about call to EIP 165 `supportsInterface` in `changeAddress`.

Steps to Verify:
----------------
1. Read the diff


