### PR TITLE
add nonce parameter to EIP 712 signatures with justification

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -102,4 +102,4 @@ contentHash
 W3C
 Mastodon
 0.8.x.
-Nonce
+Nonces

--- a/.spelling
+++ b/.spelling
@@ -102,3 +102,4 @@ contentHash
 W3C
 Mastodon
 0.8.x.
+Nonce

--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -14,11 +14,7 @@ while maintaining all graph connections, public and private.
 
 | Version | Status |
 ---------- | ---------
-<<<<<<< HEAD
-| 0.2     | Tentative |
-=======
 | 0.3     | Tentative |
->>>>>>> add nonce parameter to EIP 712 signatures with justification
 
 ## Purpose
 1. Describes how the Identity Registry resolves a DSNP Id to an identity contract address
@@ -59,7 +55,11 @@ Clients resolving handles MUST implement a method to detect potential homographs
 
 ### EIP 712 Methods, Replay Attacks and Nonces
 
-The Registry supports EIP 712 methods to permit a second party to pay gas costs for address and handle changes. Once an EIP 712 transaction is made, anyone may replay that action without further authorization. This breaks our security guarantees when the registration owner has made an additional change to either address or handle. To mitigate this, the Registry contract MUST store a nonce for every registration. When it receives an EIP 712 transaction, it MUST check that the nonce parameter matches the stored nonce, and it MUST increment the stored nonce if the transaction succeeds.
+The Registry supports EIP 712 methods to permit a second party to pay gas costs for address and handle changes.
+Once an EIP 712 transaction is made, anyone may replay that action without further authorization.
+This breaks our security guarantees when the registration owner has made an additional change to either address or handle.
+To mitigate this, the Registry contract MUST store a nonce for every registration.
+When it receives an EIP 712 transaction, it MUST check that the nonce parameter matches the stored nonce, and it MUST increment the stored nonce if the transaction succeeds.
 
 If a handle is changed, the registry MUST preserve the stored nonce for the old handle.
 
@@ -183,7 +183,7 @@ interface IRegistry {
      * TODO: FIX THE ISSUE OF newAddr not being a part of the creation
      * MUST emit DSNPRegistryUpdate
      */
-    function changeAddressByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address newAddr, string handle, uint64 nonce) external;
+    function changeAddressByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address newAddr, string handle, uint32 nonce) external;
 
     /**
      * @dev Alter a DSNP Id handle
@@ -211,7 +211,7 @@ interface IRegistry {
      *      via `IDelegation(handle -> addr).isAuthorizedTo(ecrecovedAddr, Permission.OWNERSHIP_TRANSFER, block.number)`
      * MUST emit DSNPRegistryUpdate
      */
-    function changeHandleByEIP712Sig(bytes32 r, bytes32 s, uint32 v, string oldHandle, string newHandle, uint64 nonce) external;
+    function changeHandleByEIP712Sig(bytes32 r, bytes32 s, uint32 v, string oldHandle, string newHandle, uint32 nonce) external;
 
     /**
      * @dev Resolve a handle to a contract address
@@ -238,6 +238,6 @@ interface IRegistry {
      * @throws if not found
      * @returns expected nonce for next EIP 712 update
      */
-    function resolveHandleToNonce(string handle) view external returns (uint64);
+    function resolveHandleToNonce(string handle) view external returns (uint32);
 }
 ```

--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -61,6 +61,8 @@ Clients resolving handles MUST implement a method to detect potential homographs
 
 The Registry supports EIP 712 methods to permit a second party to pay gas costs for address and handle changes. Once an EIP 712 transaction is made, anyone may replay that action without further authorization. This breaks our security guarantees when the registration owner has made an additional change to either address or handle. To mitigate this, the Registry contract MUST store a nonce for every registration. When it receives an EIP 712 transaction, it MUST check that the nonce parameter matches the stored nonce, and it MUST increment the stored nonce if the transaction succeeds.
 
+If a handle is changed, the registry MUST preserve the stored nonce for the old handle.
+
 ## DSNP Ids
 
 Ethereum contract addresses are currently 160 bit values which is much larger than needed for unique identification.


### PR DESCRIPTION
closes #38

Problem
=======
As written, the EIP 712 methods in Registry have no way to guard against replay attacks.
[#178007793](https://www.pivotaltracker.com/story/show/178007793)

Solution
========
Introduce a nonce that must be stored along with registration issues, and then require the nonce parameter to be included in the signature and passed as a parameter to the EIP 712 methods. This will allow the registry to reject transactions that have already been played.

Change summary:
---------------
* Add section about EIP 712, replay attacks, and the nonce
* Add nonce parameter to EIP 712 methods
* Add view method to retrieve nonce.
