### PR TITLE
ProxyCreated + Small fixes

### DIFF
--- a/pages/Identity/Factory.md
+++ b/pages/Identity/Factory.md
@@ -16,7 +16,7 @@ Any contract that matches the [DSNP Identity](/Identity/Overview) interfaces is 
 
 | Version | Status |
 ---------- | ---------
-| 0.1     | Tentative |
+| 0.2     | Tentative |
 
 ## Purpose
 1. Describe how an Identity Factory can create an identity
@@ -87,14 +87,14 @@ interface IIdentityCloneFactory {
     /**
      * @dev Creates a new identity with the ecrecover address as the owner
      * @dev [EIP 1167](https://eips.ethereum.org/EIPS/eip-1167) Proxy
+     * @param v EIP-155 calculated Signature v value
      * @param r ECDSA Signature r value
      * @param s ECDSA Signature s value
-     * @param v EIP-155 calculated Signature v value
      * @param logic The Logic address to use for identity creation
      * 
      * @returns The address of the newly created Identity
      */
-    function createCloneByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address logic) external returns (address);
+    function createCloneByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address logic) external returns (address);
 }
 ```
 
@@ -140,14 +140,14 @@ interface IIdentityUpgradableFactory {
 
     /**
      * @dev Creates a new identity with the ecrecover address as the owner
+     * @param v EIP-155 calculated Signature v value
      * @param r ECDSA Signature r value
      * @param s ECDSA Signature s value
-     * @param v EIP-155 calculated Signature v value
      * @param logic The logic address to use for identity creation
      * 
      * @returns The address of the newly created Identity
      */
-    function createUpgradableByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address logic) external returns (address);
+    function createUpgradableByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address logic) external returns (address);
 }
 ```
 
@@ -187,14 +187,14 @@ interface IIdentityBeaconFactory {
     
     /**
      * @dev Creates a new identity with the ecrecover address as the owner
+     * @param v EIP-155 calculated Signature v value
      * @param r ECDSA Signature r value
      * @param s ECDSA Signature s value
-     * @param v EIP-155 calculated Signature v value
      * @param beacon The beacon address to use for identity creation
      *
      * @returns The address of the newly created Identity
      */
-    function createBeaconByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address beacon) external returns (address);
+    function createBeaconByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address beacon) external returns (address);
 }
 ```
 

--- a/pages/Identity/Factory.md
+++ b/pages/Identity/Factory.md
@@ -64,7 +64,7 @@ Implementations of upgradable proxies MUST use EIP 1967 style data storage.
 ## Factory
 
 An identity factory will give easy methods to allow for the creation of proxy contracts that function as DSNP Identities.
-Official implementation contract addresses will be published once deployed. 
+Official implementation contract addresses will be published once deployed.
 
 ### Clone Interface
 
@@ -75,6 +75,12 @@ Clones follow [EIP 1167](https://eips.ethereum.org/EIPS/eip-1167) for a **non-up
  * @dev DSNP Identity Factory Interface for creating identities via [EIP 1167](https://eips.ethereum.org/EIPS/eip-1167)
  */
 interface IIdentityCloneFactory {
+
+    /**
+     * @dev event to log the created proxy contract address
+     */
+    event ProxyCreated(address addr);
+
     /**
      * @dev Creates a new identity with the message sender as the owner
      * @dev [EIP 1167](https://eips.ethereum.org/EIPS/eip-1167) Proxy 
@@ -92,7 +98,8 @@ interface IIdentityCloneFactory {
      * @param s ECDSA Signature s value
      * @param logic The Logic address to use for identity creation
      * 
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createCloneByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address logic) external returns (address);
 }
@@ -107,6 +114,11 @@ Upgradable Proxies can be upgraded by the owner or permissioned delegates.
  * @dev DSNP Identity Factory Interface for creating upgradable identities
  */
 interface IIdentityUpgradableFactory {
+
+    /**
+     * @dev event to log the created proxy contract address
+     */
+    event ProxyCreated(address addr);
 
     /**
      * @dev Logs updates to the suggested logic contract
@@ -126,7 +138,8 @@ interface IIdentityUpgradableFactory {
      * @dev Creates a new identity with the message sender as the owner
      *      and will be pointed at the default identity logic address.
      * 
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createUpgradable() external returns (address);
     
@@ -134,7 +147,8 @@ interface IIdentityUpgradableFactory {
      * @dev Creates a new identity with the message sender as the owner
      * @param logic The Logic address to use for identity creation
      * 
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createUpgradable(address logic) external returns (address);
 
@@ -145,7 +159,8 @@ interface IIdentityUpgradableFactory {
      * @param s ECDSA Signature s value
      * @param logic The logic address to use for identity creation
      * 
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createUpgradableByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address logic) external returns (address);
 }
@@ -161,6 +176,11 @@ This is the suggested factory for use on Betanet to remain up to date.
  * @dev DSNP Identity Factory Interface for creating beacon following identities
  */
 interface IIdentityBeaconFactory {
+
+    /**
+     * @dev event to log the created proxy contract address
+     */
+    event ProxyCreated(address addr);
     
     /**
      * @dev This MUST NOT be upgradable by the owner of the factory
@@ -173,7 +193,8 @@ interface IIdentityBeaconFactory {
      * @dev Creates a new identity with the message sender as the owner
      *      Uses the beacon defined by getBeacon()
      * 
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createBeacon() external returns (address);
     
@@ -181,7 +202,8 @@ interface IIdentityBeaconFactory {
      * @dev Creates a new identity with the message sender as the owner
      * @param beacon The beacon address to use for identity creation
      * 
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createBeacon(address beacon) external returns (address);
     
@@ -192,7 +214,8 @@ interface IIdentityBeaconFactory {
      * @param s ECDSA Signature s value
      * @param beacon The beacon address to use for identity creation
      *
-     * @returns The address of the newly created Identity
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @returns The address of the newly created identity proxy contract
      */
     function createBeaconByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address beacon) external returns (address);
 }

--- a/pages/Identity/Factory.md
+++ b/pages/Identity/Factory.md
@@ -86,7 +86,7 @@ interface IIdentityCloneFactory {
      * @dev [EIP 1167](https://eips.ethereum.org/EIPS/eip-1167) Proxy 
      * @param logic The Logic address to use for identity creation
      * 
-     * @returns The address of the newly created Identity
+     * @return The address of the newly created Identity
      */
     function createClone(address logic) public returns (address);
 
@@ -99,7 +99,7 @@ interface IIdentityCloneFactory {
      * @param logic The Logic address to use for identity creation
      * 
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createCloneByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address logic) external returns (address);
 }
@@ -130,7 +130,7 @@ interface IIdentityUpgradableFactory {
     /**
      * @dev This may be upgradable by the owner of the factory
      *
-     * @returns The current logic contract suggested by this factory
+     * @return The current logic contract suggested by this factory
      */
     function getLogic() external view returns (address);
 
@@ -139,7 +139,7 @@ interface IIdentityUpgradableFactory {
      *      and will be pointed at the default identity logic address.
      * 
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createUpgradable() external returns (address);
     
@@ -148,7 +148,7 @@ interface IIdentityUpgradableFactory {
      * @param logic The Logic address to use for identity creation
      * 
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createUpgradable(address logic) external returns (address);
 
@@ -160,7 +160,7 @@ interface IIdentityUpgradableFactory {
      * @param logic The logic address to use for identity creation
      * 
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createUpgradableByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address logic) external returns (address);
 }
@@ -185,7 +185,7 @@ interface IIdentityBeaconFactory {
     /**
      * @dev This MUST NOT be upgradable by the owner of the factory
      *
-     * @returns The current beacon contract suggested by this factory
+     * @return The current beacon contract suggested by this factory
      */
     function getBeacon() external view returns (address);
 
@@ -194,7 +194,7 @@ interface IIdentityBeaconFactory {
      *      Uses the beacon defined by getBeacon()
      * 
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createBeacon() external returns (address);
     
@@ -203,7 +203,7 @@ interface IIdentityBeaconFactory {
      * @param beacon The beacon address to use for identity creation
      * 
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createBeacon(address beacon) external returns (address);
     
@@ -215,7 +215,7 @@ interface IIdentityBeaconFactory {
      * @param beacon The beacon address to use for identity creation
      *
      * @dev This MUST emit ProxyCreated with the address of the new proxy contract
-     * @returns The address of the newly created identity proxy contract
+     * @return The address of the newly created identity proxy contract
      */
     function createBeaconByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address beacon) external returns (address);
 }

--- a/pages/Identity/Overview.md
+++ b/pages/Identity/Overview.md
@@ -12,7 +12,7 @@ This specification is intended to cover the concept of identity within the proto
 
 | Version | Status |
 ---------- | ---------
-| 0.2     | Tentative |
+| 0.3     | Tentative |
 
 ## Purpose
 
@@ -151,9 +151,9 @@ interface IDelegation {
 
     /**
      * @dev Add or change permissions for delegate by EIP-712 signature
+     * @param v EIP-155 calculated Signature v value
      * @param r ECDSA Signature r value
      * @param s ECDSA Signature s value
-     * @param v EIP-155 calculated Signature v value
      * @param newDelegate Address to delegate new permissions to
      * @param permission Permission level
      * 
@@ -161,7 +161,7 @@ interface IDelegation {
      * MUST consider newDelegate to be valid from the beginning to time
      * MUST emit DSNPAddDelegate
      */
-    function delegateByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address newDelegate, Role role) external;
+    function delegateByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address newDelegate, Role role) external;
 
     /**
      * @dev Remove Delegate
@@ -178,15 +178,15 @@ interface IDelegation {
      * @dev Remove Delegate By EIP-712 Signature
      * @param delegate Address to remove all permissions from
      * @param endBlock Block number to consider the permissions terminated (MUST be > 0x0).
+     * @param v EIP-155 calculated Signature v value
      * @param r ECDSA Signature r value
      * @param s ECDSA Signature s value
-     * @param v EIP-155 calculated Signature v value
      * 
      * MUST be signed by the delegate, owner, or other delegate with permissions
      * MUST store endBlock for response in isAuthorizedToAnnounce
      * MUST emit DSNPRemoveDelegate
      */
-    function delegateRemoveByEIP712Sig(bytes32 r, bytes32 s, uint32 v, address delegate, uint64 endBlock) external;
+    function delegateRemoveByEIP712Sig(uint8 v, bytes32 r, bytes32 s, address delegate, uint64 endBlock) external;
 
     /**
      * @dev Checks to see if address is authorized to announce messages

--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -224,7 +224,7 @@ interface IRegistry {
      * @param handle The handle to resolve
      * 
      * @throws if not found
-     * @returns Address of the contract
+     * @return Address of the contract
      */
     function resolveHandleToAddress(string handle) view external returns (address);
 
@@ -233,7 +233,7 @@ interface IRegistry {
      * @param handle The handle to resolve
      * 
      * @throws if not found
-     * @returns DSNP Id
+     * @return DSNP Id
      */
     function resolveHandleToId(string handle) view external returns (uint64);
 
@@ -242,7 +242,7 @@ interface IRegistry {
      * @param handle The handle to resolve
      * 
      * @throws if not found
-     * @returns expected nonce for next EIP 712 update
+     * @return expected nonce for next EIP 712 update
      */
     function resolveHandleToNonce(string handle) view external returns (uint32);
 }


### PR DESCRIPTION
Problem
=======
Transaction methods cannot have a return value, so we need to log an event for proxy creation:

> [Write methods] cannot return a result. If a result is required, it should be logged using a Solidity event (or EVM log), which can then be queried from the transaction receipt.
Re: https://docs.ethers.io/v5/api/contract/contract/#Contract--write

[Pivotal Tracker #12345678](https://www.pivotaltracker.com/story/show/177872358)

Solution
========
Add ProxyCreated event with the needed data

Change summary:
---------------
* Add ProxyCreated event with the needed data
* Update EIP 712 methods to match #42 
* Fix typo of @returns instead of @return
