### PR TITLE
Bugs/update signing spec for eth rpm limitations 177926856

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -133,3 +133,7 @@ validator
 versioning
 W3C
 Whitepaper
+followee
+prepended
+RPC
+x19Ethereum

--- a/pages/Messages/Signatures.md
+++ b/pages/Messages/Signatures.md
@@ -34,7 +34,7 @@ The process for generating signatures for DSNP announcements consists of three d
 To serialize messages, objects must first be converted to a string then prepended with the standard [Ethereum RPC prefix](https://eth.wiki/json-rpc/API#eth_sign).
 To convert encrypted messages to a string, the bytes of the message should be encoded in [base 64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).
 To convert non-encrypted messages to a string, each key of the DSNP object should be concatenated with its value in alphabetical order.
-Once converted, the string must be prefixed with "\x19Ethereum Signed Message:\n" and the length of the string.
+Once converted, the string must be prefixed with "\x19Ethereum Signed Message:\n" and the byte length of the string.
 
 Once the data is serialized, the serialized string should be hashed using [keccak-256](https://en.wikipedia.org/wiki/SHA-3).
 This fixed length hash generated can then be signed using [secp256k1](https://google.com/search?hl=en&q=secp256k1) and the publishing user's private key.
@@ -53,19 +53,19 @@ For example, given the following DSNP broadcast message:
 This would be the expected serialization:
 
 ```
-\x19Ethereum Signed Message:\n69contentHash0x67890fromAddress0x12345urihttps://www.projectliberty.io/
+\x19Ethereum Signed Message:\n\x69contentHash0x67890fromAddress0x12345urihttps://www.projectliberty.io/
 ```
 
 This would be the expected hash:
 
 ```
-0x1850c765b8dd0c4a0d57585f2eb543c66f2857354051d5f867155d25da8d9c66
+0x4c233fc1d71f92e4b8b7408291d45b5aa2ec3689d14091abc9207c4eca3886ad
 ```
 
 And the generated signature would be a string unique to the signing user's keys but looking something like this:
 
 ```
-XPBsWQeGibKRqiN18o+4nhCMqlq9URj8Dj/o23x6GUTFMDuefNnadq3LNF94YeSnNAO6PlRIEFILXnkTtgouDw==
+0xf9d3010a7b1f199b5ea58473908c0c78a5cb04fdead2a05a7961c9a7ff87f1e81c654605b50f65b7d255177b0b49bbd97fa07fb88f9a7ea90565baa96b68e61e
 ```
 
 ## Verifying Messages
@@ -76,5 +76,5 @@ The user's public key can be fetched from the Identity contract as described in 
 Given the message and signature provided in the previous example, the following public key should return a matching hash when verifying:
 
 ```
-FJLtOPk1bYjDUwAYezuo+1DVSj1glLUjYtt9ZTm2NJY=
+0x033dd49eb9790f8473399093c10eead398bbd76eae0905b9b26fd550aced63e858
 ```

--- a/pages/Messages/Signatures.md
+++ b/pages/Messages/Signatures.md
@@ -64,7 +64,17 @@ This would be the expected hash:
 And the generated signature would be a string unique to the signing user's keys but looking something like this:
 
 ```
-0x4f730177f9cca0a69b0e7fa96e9fcb7d41bfd56da36c05a7a107a8e201ae63d0741a74bde1b161b072caa8c0bdd6a5f6425061a234e23e840ee782c3afb426bc00
+{
+  v: "0x1c",
+  r: "0x60548fc39c248a6cbcf085854238c6cf66d44ab16a64faace38bf3f03f42400f",
+  s: "0x4b0cf86049606203f0334cdc0118d4b09244881dd22d3722e618648469defcc7"
+}
+```
+
+The compressed form of the above being this:
+
+```
+0x60548fc39c248a6cbcf085854238c6cf66d44ab16a64faace38bf3f03f42400f4b0cf86049606203f0334cdc0118d4b09244881dd22d3722e618648469defcc71c
 ```
 
 ## Verifying Messages
@@ -75,5 +85,5 @@ The user's public key can be fetched from the Identity contract as described in 
 Given the message and signature provided in the previous example, the elliptic curve recovery should match the following ETH address:
 
 ```
-0xEcFA326197Df5eA2fb5DbE872579e4b5e41ace2f
+0x60b5Af7F23489339acBA7B1c85171Ef9D8f4A1d1
 ```

--- a/pages/Messages/Signatures.md
+++ b/pages/Messages/Signatures.md
@@ -32,8 +32,7 @@ The process for generating signatures for DSNP announcements consists of three d
 1. Sign the hash
 
 To serialize messages, objects must first be converted to a string then prepended with the standard [Ethereum RPC prefix](https://eth.wiki/json-rpc/API#eth_sign).
-To convert encrypted messages to a string, the bytes of the message should be encoded in [base 64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).
-To convert non-encrypted messages to a string, each key of the DSNP object should be concatenated with its value in alphabetical order.
+To convert messages to a string, each key of the DSNP object should be concatenated with its value in alphabetical order.
 Once converted, the string must be prefixed with "\x19Ethereum Signed Message:\n" and the byte length of the string.
 
 Once the data is serialized, the serialized string should be hashed using [keccak-256](https://en.wikipedia.org/wiki/SHA-3).
@@ -53,19 +52,19 @@ For example, given the following DSNP broadcast message:
 This would be the expected serialization:
 
 ```
-\x19Ethereum Signed Message:\n\x69contentHash0x67890fromAddress0x12345urihttps://www.projectliberty.io/
+\x19Ethereum Signed Message:\n69contentHash0x67890fromAddress0x12345urihttps://www.projectliberty.io/
 ```
 
 This would be the expected hash:
 
 ```
-0x4c233fc1d71f92e4b8b7408291d45b5aa2ec3689d14091abc9207c4eca3886ad
+0x6ad0d59e6d5f7aaee5998e5d584d8c55a3c01f09bf0f5b4c49b2399eca22a82a
 ```
 
 And the generated signature would be a string unique to the signing user's keys but looking something like this:
 
 ```
-0xf9d3010a7b1f199b5ea58473908c0c78a5cb04fdead2a05a7961c9a7ff87f1e81c654605b50f65b7d255177b0b49bbd97fa07fb88f9a7ea90565baa96b68e61e
+0xdef248a5cd62607930076bbc627f6ca9ff95c3e4ca9fab340bd4a110c9f644ca2dcfebb32d779f9ad9f3b2acf197f8f983a971f176b41952f556201b7e88fd42
 ```
 
 ## Verifying Messages
@@ -73,8 +72,8 @@ And the generated signature would be a string unique to the signing user's keys 
 Verifying announcements can be done by repeating the serialization and hashing steps from the signing process then validating the generated hash against the publishing user's public key.
 The user's public key can be fetched from the Identity contract as described in the [Identity spec](/Identity/Overview).
 
-Given the message and signature provided in the previous example, the following public key should return a matching hash when verifying:
+Given the message and signature provided in the previous example, the elliptic curve recovery should match the following public key:
 
 ```
-0x033dd49eb9790f8473399093c10eead398bbd76eae0905b9b26fd550aced63e858
+0x0360834d247af013d6aa2dbec114aea49b163c4fda488cf708fe3b84148aead5b8
 ```

--- a/pages/Messages/Signatures.md
+++ b/pages/Messages/Signatures.md
@@ -64,7 +64,7 @@ This would be the expected hash:
 And the generated signature would be a string unique to the signing user's keys but looking something like this:
 
 ```
-0xdef248a5cd62607930076bbc627f6ca9ff95c3e4ca9fab340bd4a110c9f644ca2dcfebb32d779f9ad9f3b2acf197f8f983a971f176b41952f556201b7e88fd42
+0x4f730177f9cca0a69b0e7fa96e9fcb7d41bfd56da36c05a7a107a8e201ae63d0741a74bde1b161b072caa8c0bdd6a5f6425061a234e23e840ee782c3afb426bc00
 ```
 
 ## Verifying Messages
@@ -72,8 +72,8 @@ And the generated signature would be a string unique to the signing user's keys 
 Verifying announcements can be done by repeating the serialization and hashing steps from the signing process then validating the generated hash against the publishing user's public key.
 The user's public key can be fetched from the Identity contract as described in the [Identity spec](/Identity/Overview).
 
-Given the message and signature provided in the previous example, the elliptic curve recovery should match the following public key:
+Given the message and signature provided in the previous example, the elliptic curve recovery should match the following ETH address:
 
 ```
-0x0360834d247af013d6aa2dbec114aea49b163c4fda488cf708fe3b84148aead5b8
+0xEcFA326197Df5eA2fb5DbE872579e4b5e41ace2f
 ```

--- a/pages/Messages/Signatures.md
+++ b/pages/Messages/Signatures.md
@@ -31,8 +31,10 @@ The process for generating signatures for DSNP announcements consists of three d
 1. Hash the serialized string
 1. Sign the hash
 
-For encrypted messages, the encrypted bytes of the `dsnpData` field can be hashed directly without any serialization.
-For non-encrypted messages, each key-value pair in the `dsnpData` object should be concatenated in alphabetical order with no separator characters.
+To serialize messages, objects must first be converted to a string then prepended with the standard [Ethereum RPC prefix](https://eth.wiki/json-rpc/API#eth_sign).
+To convert encrypted messages to a string, the bytes of the message should be encoded in [base 64](https://developer.mozilla.org/en-US/docs/Glossary/Base64).
+To convert non-encrypted messages to a string, each key of the DSNP object should be concatenated with its value in alphabetical order.
+Once converted, the string must be prefixed with "\x19Ethereum Signed Message:\n" and the length of the string.
 
 Once the data is serialized, the serialized string should be hashed using [keccak-256](https://en.wikipedia.org/wiki/SHA-3).
 This fixed length hash generated can then be signed using [secp256k1](https://google.com/search?hl=en&q=secp256k1) and the publishing user's private key.
@@ -51,19 +53,19 @@ For example, given the following DSNP broadcast message:
 This would be the expected serialization:
 
 ```
-contentHash0x67890fromAddress0x12345urihttps://www.projectliberty.io/
+\x19Ethereum Signed Message:\n69contentHash0x67890fromAddress0x12345urihttps://www.projectliberty.io/
 ```
 
 This would be the expected hash:
 
 ```
-0x45c42591e0154088325055f26664002bf05f211db9e5d7c7bfc588dc309698e0
+0x1850c765b8dd0c4a0d57585f2eb543c66f2857354051d5f867155d25da8d9c66
 ```
 
 And the generated signature would be a string unique to the signing user's keys but looking something like this:
 
 ```
-LJbwyo6oxKd2GRxsUFwxUN1YwBzE9UC4WPvScsh0+vALkocQn60QjgkNd9CB0JUKfVTQdOlTm5gzaengzgmhDw==
+XPBsWQeGibKRqiN18o+4nhCMqlq9URj8Dj/o23x6GUTFMDuefNnadq3LNF94YeSnNAO6PlRIEFILXnkTtgouDw==
 ```
 
 ## Verifying Messages
@@ -71,8 +73,8 @@ LJbwyo6oxKd2GRxsUFwxUN1YwBzE9UC4WPvScsh0+vALkocQn60QjgkNd9CB0JUKfVTQdOlTm5gzaeng
 Verifying announcements can be done by repeating the serialization and hashing steps from the signing process then validating the generated hash against the publishing user's public key.
 The user's public key can be fetched from the Identity contract as described in the [Identity spec](/Identity/Overview).
 
-Given the message and signature provided in the previous example, the following public key should return true when verifying:
+Given the message and signature provided in the previous example, the following public key should return a matching hash when verifying:
 
 ```
-+IUGiZsGHq+3s/Zgxl8TQMRgydvsOX1hUwMzHykoqGw=
+FJLtOPk1bYjDUwAYezuo+1DVSj1glLUjYtt9ZTm2NJY=
 ```


### PR DESCRIPTION
Problem
=======
The standard Ethereum RPC provided by MetaMask and other wallets does not include a `signDigest` method, only a `sign` method which automatically prefixes all messages
[#177926856](https://www.pivotaltracker.com/story/show/177926856)

Solution
========
Update our signatures spec to include this prefix so we can use wallet signing