### PR TITLE
Add batches menu to the correct location

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -72,6 +72,12 @@ export default {
       ]
     },
     {
+      name: "Batches",
+      menu: [
+        "Overview",
+      ],
+    },
+    {
       name: "Archivists",
       menu: [
         "Overview",

--- a/doczrc.js
+++ b/doczrc.js
@@ -53,8 +53,6 @@ export default {
       name: "Identity",
       menu: [
         "Overview",
-        "Factory",
-        "Registry",
       ]
     },
     {
@@ -67,8 +65,6 @@ export default {
       name: "Messages",
       menu: [
         "Overview",
-        "Serialization",
-        "Types",
       ]
     },
     {
@@ -81,7 +77,6 @@ export default {
       name: "Archivists",
       menu: [
         "Overview",
-        "Format",
       ]
     },
     {


### PR DESCRIPTION
Problem
=======
Batches was showing up at the bottom of the menu and serialization was in the menu when it was deleted.

Closes #78 
[link to Pivotal Tracker #178284852](https://www.pivotaltracker.com/story/show/178284852)

Solution
========
Added batches to the menu and removed all extra subs to go alphabetical except for "Overview"



