### PR TITLE
Add createAndRegisterBeaconFactory function

### DIFF
--- a/pages/Identity/Factory.md
+++ b/pages/Identity/Factory.md
@@ -219,6 +219,22 @@ interface IIdentityBeaconFactory {
      * @return The address of the newly created proxy contract
      */
     function createBeaconProxyWithOwner(address beacon, address owner) external returns (address);
+
+    /**
+     * @dev Creates a new identity with the adddress as the owner and registers it with a handle
+     * @param beacon The beacon address to use logic contract resolution
+     * @param owner The initial owner's address of the new contract
+     * @param handle The handle the new identity proxy under which should be registered
+     *
+     * @dev This MUST emit ProxyCreated with the address of the new proxy contract
+     * @dev This MUST revert if registration reverts
+     * @dev This MUST emit a DSNPRegistryUpdate
+     */
+    function createAndRegisterBeaconProxy(
+        address beacon,
+        address owner,
+        string calldata handle
+    ) external;
 }
 ```
 


### PR DESCRIPTION
Problem
=======
Currently, new users must make two sequential transactions to create an identity: the first to create a proxy and the second to register a handle using the address of the proxy. Sequential transactions require more gas, more time, and more complicated error handling code on the client.

Solution
========
This PR introduces a `createAndRegisterBeaconProxy` method on the beacon factory that creates the proxy and registers it in one step. This function simply calls `createBeaconProxyWithOwner` and then `Registry.register`.

Change summary:
---------------
* Add `createAndRegisterBeaconProxy` signature.

