### PR TITLE
Fix broken link to Developer Portal

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -94,7 +94,7 @@ export default {
       name: "Future Proposals", route: 'https://github.com/LibertyDSNP/spec/issues?q=label%3Aenhancement'
     },
     {
-      name: '↩ Developer Portal', route: 'https://www.projectliberty.io/#/developer-portal'
+      name: '↩ Developer Portal', route: 'https://www.dsnp.org/developer-portal/'
     }
   ]
 }


### PR DESCRIPTION
One line change, use the new location for the developer portal

Fixes Issue #91 

### How to Verify
1. check out the branch
2. `npm run serve`
3. go to localhost:3001 and click on "Developer Portal"
4. Link should take you to the Developer Portal