### PR TITLE
Updated all instances of hexadecimal in spec to use 0x prefix

### DIFF
--- a/pages/Announcements/Overview.md
+++ b/pages/Announcements/Overview.md
@@ -38,7 +38,7 @@ Most serializations use outside standards, but some require additional clarifica
 
 - MUST use 0-9,a-f representation
 - MUST be lowercase
-- MUST NOT be prefixed
+- MUST be prefixed with a `0x`
 - MUST NOT have spaces
 
 ## Duplicate Handling

--- a/pages/Identifiers.md
+++ b/pages/Identifiers.md
@@ -16,13 +16,14 @@ route: /Identifiers
 - MUST be registered in the [Identity Registry](/Identity/Registry)
 - MUST be hexadecimal
 - MUST truncate any leading zeros
-- MUST NOT have a `0x` prefix
+- MUST have a `0x` prefix
 - MUST NOT be longer than 8 bytes
 
 ## DSNP Content Hash
 
 - MUST be hexadecimal
 - MUST be 32 bytes long
+- MUST have a `0x` prefix
 - MUST be a [keccak-256 hash](https://keccak.team/files/Keccak-submission-3.pdf) of the bytes of the content
 
 ### DSNP Protocol Scheme
@@ -37,11 +38,11 @@ Any [Announcement Types](/Announcements/Overview#announcement-types) with a `fro
 
 ### Example
 ```
-dsnp://1234567890abcdef/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+dsnp://0x1234567890abcdef/0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 | part | value |
 | ---- |------ |
 | Scheme | `dsnp://` |
-| User Id | `1234567890` |
-| Content Hash | `0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef` |
+| User Id | `0x1234567890` |
+| Content Hash | `0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef` |


### PR DESCRIPTION
Problem
=======
We're currently inconsistent in our usage of prefixes on hexadecimal content because some of our underlying libraries use a `0x` prefix and some use no prefix at all.
[#178965517](https://www.pivotaltracker.com/story/show/178965517)

Solution
========
Use a 0x prefix everywhere and convert where non-prefixed hex is needed.

Change summary:
---------------
* Updated all hexadecimal requirements to include a `0x` prefix requirement.
