### PR TITLE
DSNP URIs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -92,6 +92,7 @@ SQLite
 SVG
 TBD
 TODO
+URI
 URLs
 UTF-8
 UpgradeableBeacon

--- a/pages/Announcements/Overview.md
+++ b/pages/Announcements/Overview.md
@@ -20,7 +20,7 @@ All Announcements have a [signature](/Announcements/Signatures) to validate the 
 
 Each Announcement has a enumerated type for use when separating out a stream of Announcements.
 
-| Value | Name | Description | DSNP Announcement Id |
+| Value | Name | Description | DSNP Announcement URI |
 |------ | ---- | ----------- | -------------------- |
 | 0 | Reserved | reserved for future use | - |
 | 1 | [Graph Change](/Announcements/Types/GraphChange) | social graph changes | no |

--- a/pages/Announcements/Types/Reaction.md
+++ b/pages/Announcements/Types/Reaction.md
@@ -14,7 +14,7 @@ menu: Announcements
 
 ## Details
 
-A Reaction Announcement is for publishing emoji reactions to anything with a [DSNP Announcement Id](/Identifiers#dsnp-announcement-id).
+A Reaction Announcement is for publishing emoji reactions to anything with a [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri).
 
 ## Fields
 
@@ -24,7 +24,7 @@ A Reaction Announcement is for publishing emoji reactions to anything with a [DS
 | createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | emoji | the encoded reaction | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
 | fromId | id of the user creating the relationship | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
-| inReplyTo | Target [DSNP Announcement Id](/Identifiers#dsnp-announcement-id) | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
+| inReplyTo | Target [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri) | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
 | signature | creator signature | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | no
 
 ## Field Requirements
@@ -63,7 +63,7 @@ None of the following should be considered valid:
 
 ### inReplyTo
 
-- MUST be a [DSNP Announcement Id](/Identifiers#dsnp-announcement-id)
+- MUST be a [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri)
 
 ### signature
 

--- a/pages/Announcements/Types/Reply.md
+++ b/pages/Announcements/Types/Reply.md
@@ -7,7 +7,7 @@ menu: Announcements
 # Reply Announcement
 
 A Reply Announcement is the same as a [Broadcast Announcement](/Announcements/Types/Broadcast),
-but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Announcement Id](/Identifiers#dsnp-announcement-id).
+but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri).
 
 ## Specification Status
 
@@ -23,7 +23,7 @@ but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Anno
 | contentHash | keccak-256 hash of content stored at URL | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | fromId | id of the user creating the announcement | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
-| inReplyTo | Target [DSNP Announcement Id](/Identifiers#dsnp-announcement-id) | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
+| inReplyTo | Target [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri) | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
 | url | content URL | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | no
 | signature | creator signature | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | no
 
@@ -49,7 +49,7 @@ but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Anno
 
 ### inReplyTo
 
-- MUST be a [DSNP Announcement Id](/Identifiers#dsnp-announcement-id)
+- MUST be a [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri)
 
 ### url
 

--- a/pages/Identifiers.md
+++ b/pages/Identifiers.md
@@ -30,6 +30,21 @@ route: /Identifiers
 
 - MUST always be the string `dsnp://`
 
+## DSNP User URI
+
+DSNP User URI consists of two parts, the scheme and the user id.
+It is used to identify a user via a URI.
+
+### Example
+```
+dsnp://0x1234567890abcdef
+```
+
+| part | value |
+| ---- | ----- |
+| Scheme | `dsnp://` |
+| User Id | `0x1234567890abcdef` |
+
 ## DSNP Announcement URI
 
 DSNP Announcement URI consists of three parts, the scheme, the user id, and the content hash.

--- a/pages/Identifiers.md
+++ b/pages/Identifiers.md
@@ -30,11 +30,12 @@ route: /Identifiers
 
 - MUST always be the string `dsnp://`
 
-## DSNP Announcement Id
+## DSNP Announcement URI
 
-DSNP Announcement Id consists of three parts, the scheme, the user id, and the content hash.
+DSNP Announcement URI consists of three parts, the scheme, the user id, and the content hash.
+It is used to uniquely identify an announcements from a given user with content.
 
-Any [Announcement Types](/Announcements/Overview#announcement-types) with a `fromId` and `contentHash` have a DSNP Announcement Id.
+Any [Announcement Types](/Announcements/Overview#announcement-types) with a `fromId` and `contentHash` have a DSNP Announcement URI.
 
 ### Example
 ```
@@ -42,7 +43,7 @@ dsnp://0x1234567890abcdef/0x0123456789abcdef0123456789abcdef0123456789abcdef0123
 ```
 
 | part | value |
-| ---- |------ |
+| ---- | ----- |
 | Scheme | `dsnp://` |
 | User Id | `0x1234567890` |
 | Content Hash | `0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef` |


### PR DESCRIPTION
Problem
=======
1. We needed a URI compliant way to refer to users for mentions in Activity Content.
2. DSNP Announcement Id was misnamed. It is a URI, not an Id

Solution
========
Renamed DSNP Announcement Id -> DSNP Announcement URI
Created DSNP User URI

