### PR TITLE
Update createdAt to use milliseconds instead of microseconds

### DIFF
--- a/pages/Announcements/Types/Broadcast.md
+++ b/pages/Announcements/Types/Broadcast.md
@@ -20,7 +20,7 @@ A Broadcast Announcement is a way to send a public message to everyone.
 | ----- | ----------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`2`) | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT32` | no |
 | contentHash | keccak-256 hash of content stored at URL | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
-| createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
+| createdAt | milliseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | fromId | id of the user creating the announcement | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | url | content URL | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | no
 | signature | creator signature | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | no
@@ -38,7 +38,7 @@ A Broadcast Announcement is a way to send a public message to everyone.
 
 ### createdAt
 
-- MUST be set to the microseconds since Unix epoch at time of signing
+- MUST be set to the milliseconds since Unix epoch at time of signing
 
 ### fromId
 

--- a/pages/Announcements/Types/GraphChange.md
+++ b/pages/Announcements/Types/GraphChange.md
@@ -21,7 +21,7 @@ A Graph Change Announcement is for publishing relationship state changes for a u
 | ----- | ----------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`1`) | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT32` | no |
 | changeType | Type of relationship change | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT32` | no
-| createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
+| createdAt | milliseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | fromId | id of the user creating the relationship | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | objectId | id of the target of the relationship | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | signature | creator signature | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | no
@@ -47,7 +47,7 @@ Different change types have different meanings
 
 ### createdAt
 
-- MUST be set to the microseconds since Unix epoch at time of signing
+- MUST be set to the milliseconds since Unix epoch at time of signing
 - MUST be unique for the given `fromId` and `objectId` pair
 
 ### fromId
@@ -70,7 +70,7 @@ Different change types have different meanings
 Clients must ignore any Graph Change event that comes after another event with the same signature.
 This avoids [Replay attacks](https://en.wikipedia.org/wiki/Replay_attack)
 Each graph change event has a `createAt` that allows for differing signatures.
-The `createAt` is set to the timestamp is represented as microseconds since Unix epoch.
+The `createAt` is set to the timestamp is represented as milliseconds since Unix epoch.
 
 For example:
 1. Bob "follows" Charlie and then "unfollows" him then "follows" him again.

--- a/pages/Announcements/Types/Profile.md
+++ b/pages/Announcements/Types/Profile.md
@@ -21,7 +21,7 @@ The reference content *MUST be of profile type*.
 | ----- | ----------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`5`) | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT32` | no |
 | contentHash | keccak-256 hash of content stored at URL | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
-| createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
+| createdAt | milliseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | fromId | id of the user creating the announcement | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | url | Profile content URL | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | no
 | signature | creator signature | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | no
@@ -39,7 +39,7 @@ The reference content *MUST be of profile type*.
 
 ### createdAt
 
-- MUST be set to the microseconds since Unix epoch at time of signing
+- MUST be set to the milliseconds since Unix epoch at time of signing
 
 ### fromId
 

--- a/pages/Announcements/Types/Reaction.md
+++ b/pages/Announcements/Types/Reaction.md
@@ -21,7 +21,7 @@ A Reaction Announcement is for publishing emoji reactions to anything with a [DS
 | Field | Description | Serialization | Parquet Type | Bloom Filter |
 | ----- | ----------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`4`) | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT32` | no |
-| createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
+| createdAt | milliseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | emoji | the encoded reaction | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
 | fromId | id of the user creating the relationship | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | inReplyTo | Target [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri) | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
@@ -35,7 +35,7 @@ A Reaction Announcement is for publishing emoji reactions to anything with a [DS
 
 ### createdAt
 
-- MUST be set to the microseconds since Unix epoch at time of signing
+- MUST be set to the milliseconds since Unix epoch at time of signing
 
 ### emoji
 

--- a/pages/Announcements/Types/Reply.md
+++ b/pages/Announcements/Types/Reply.md
@@ -21,7 +21,7 @@ but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Anno
 | ----- | ----------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`3`) | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT32` | no |
 | contentHash | keccak-256 hash of content stored at URL | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
-| createdAt | microseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
+| createdAt | milliseconds since Unix epoch | [hexadecimal](/Announcements/Overview#hexadecimal) | `INT64` | no
 | fromId | id of the user creating the announcement | [hexadecimal](/Announcements/Overview#hexadecimal) | `BYTE_ARRAY` | YES
 | inReplyTo | Target [DSNP Announcement URI](/Identifiers#dsnp-announcement-uri) | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | YES
 | url | content URL | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `BYTE_ARRAY` | no
@@ -40,7 +40,7 @@ but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Anno
 
 ### createdAt
 
-- MUST be set to the microseconds since Unix epoch at time of signing
+- MUST be set to the milliseconds since Unix epoch at time of signing
 
 ### fromId
 


### PR DESCRIPTION
Problem
=======
Not all platforms support microseconds, so it is good enough to use milliseconds for `createdAt`

Discussed at Weekly Spec Meeting 2021-07-22

Solution
========
use milliseconds for createdAt

Change summary:
---------------
* createdAt uses milliseconds

