### PR TITLE
resolveRegistration should return zeros if not found

### DIFF
--- a/pages/Identity/Registry.md
+++ b/pages/Identity/Registry.md
@@ -212,7 +212,7 @@ interface IRegistry {
      * @dev Resolve a handle to a DSNP User Id and contract address
      * @param handle The handle to resolve
      *
-     * rejects if not found
+     * Returns zeros if not found
      * @return A tuple of the DSNP User Id and the Address of the contract
      */
     function resolveRegistration(string calldata handle) view external returns (uint64, address);

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,7 +5,7 @@ route: /
 
 # DSNP Specification
 
-## Version 0.9.0
+## Version 0.9.1
 
 Welcome to the Decentralized Social Networking Protocol (DSNP) specification!
 Here you can find a detailed documentation regarding the current state of the protocol, previous iterations and proposals for future extensions.


### PR DESCRIPTION
Problem
=======
Some evm implementations will not return the vm error message or not return it consistently, so return zeros instead for not found.

Solution
========
zeros instead for not found

