### PR TITLE
Hexadecimal serialization clarification

### DIFF
--- a/pages/ActivityContent/Associated/Hash.md
+++ b/pages/ActivityContent/Associated/Hash.md
@@ -31,7 +31,7 @@ AT LEAST ONE hash in the array MUST be one of the [supported algorithms](#suppor
   "hash": [
     {
       "algorithm": "keccak256",
-      "value": "0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+      "value": "0x1234567890ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
     }
   ]
 }

--- a/pages/Announcements/Overview.md
+++ b/pages/Announcements/Overview.md
@@ -34,6 +34,14 @@ Most serializations use outside standards, but some require additional clarifica
 - MUST be lowercase
 - MUST be prefixed with a `0x`
 - MUST NOT have spaces
+- MUST NOT have any zero padding
+
+| Bytes | Invalid | Valid |
+| --- | --- | --- |
+| 2 | `0x0123` | `0x123` |
+| 2 | `123h` | `0x123` |
+| 8 | `0x0000000000000abc` | `0xabc` |
+| 32 | `0x00003e34c4325f4461b9355027b314f3eb56d31af549f7da7bd9ef1ce951651e` | `0x3e34c4325f4461b9355027b314f3eb56d31af549f7da7bd9ef1ce951651e` |
 
 ## Duplicate Handling
 

--- a/pages/Announcements/Signatures.md
+++ b/pages/Announcements/Signatures.md
@@ -30,22 +30,24 @@ All parties interacting with Announcements should independently validate signatu
 
 ```json
 {
+  "announcementType": 1,
   "fromId": "0x12345",
   "contentHash": "0x67890",
-  "url": "https://www.projectliberty.io/"
+  "url": "https://www.dsnp.org/",
+  "createdAt": "2021-07-31T10:11:12"
 }
 ```
 
 Expected serialization:
 
 ```
-\x19Ethereum Signed Message:\n64contentHash0x67890fromId0x12345urlhttps://www.projectliberty.io/
+\x19Ethereum Signed Message:\n64announcementType0x1contentHash0x67890createdAt0x17afc0bd600fromId0x12345urlhttps://www.dsnp.org/
 ```
 
 Serialization in hexadecimal:
 
 ```
-0x19457468657265756d205369676e6564204d6573736167653a0a3634636f6e74656e74486173683078363738393066726f6d49643078313233343575726c68747470733a2f2f7777772e70726f6a6563746c6962657274792e696f2f
+0x19457468657265756d205369676e6564204d6573736167653a0a3936616e6e6f756e63656d656e7454797065307831636f6e74656e7448617368307836373839306372656174656441743078313761666330626436303066726f6d49643078313233343575726c68747470733a2f2f7777772e64736e702e6f72672f
 ```
 
 ### Hashing
@@ -57,7 +59,7 @@ Serialization in hexadecimal:
 For the previous example, the resulting hexadecimal hash MUST match:
 
 ```
-0x47a23e34c4325f4461b9355027b314f3eb56d31af549f7da7bd9ef1ce951651e
+0xe998171b9eedfe13a181aa158c7b2dbb739af9e5ca062cc5822e668be1314478
 ```
 
 
@@ -76,16 +78,16 @@ Private Key: `0xd9d3b5afb7765ffd9f047fd0d1d9b47d4d538b6a56f1cf29dc160ab9c6d30aa3
 
 ```
 {
-  v: '0x1b',
-  r: '0xfb2260acfacf83bbb1fdac8a7126a14322c9163c20c6c87d7e9aac72fd15bd34',
-  s: '0x6c1854bdd441e5086b3cfb64c45e78a4cff83878e92ce378ee689343214cdcd6',
+  v: '0x1c',
+  r: '0xa34e5f6ba5f133cc1c8dfed613ad913f07dc5dff38c92278f9253c07ff43bd1d',
+  s: '0x3f86a862db3db7223a2d2b530dd15cbdc450fb2394917f1f413f4a102822deca',
 }
 ```
 
 The compressed form of the above being this (`r + s + v`):
 
 ```
-0xfb2260acfacf83bbb1fdac8a7126a14322c9163c20c6c87d7e9aac72fd15bd346c1854bdd441e5086b3cfb64c45e78a4cff83878e92ce378ee689343214cdcd61b
+0xa34e5f6ba5f133cc1c8dfed613ad913f07dc5dff38c92278f9253c07ff43bd1d3f86a862db3db7223a2d2b530dd15cbdc450fb2394917f1f413f4a102822deca1c
 ```
 
 ## Validating a Signature

--- a/pages/Identifiers.md
+++ b/pages/Identifiers.md
@@ -7,17 +7,15 @@ route: /Identifiers
 
 ## DSNP User Id
 
+- Is 8 bytes in size
 - MUST be registered in the [Identity Registry](/Identity/Registry)
-- MUST be hexadecimal
-- MUST have a `0x` prefix
-- MUST NOT be longer than 8 bytes
+- MUST be serialized as [hexadecimal](/Announcements/Overview#hexadecimal)
 
 ## DSNP Content Hash
 
-- MUST be hexadecimal
-- MUST be 32 bytes long
-- MUST have a `0x` prefix
+- Is 32 bytes in size
 - MUST be a [keccak-256 hash](https://keccak.team/files/Keccak-submission-3.pdf) of the bytes of the content
+- MUST be serialized as [hexadecimal](/Announcements/Overview#hexadecimal)
 
 ### DSNP Protocol Scheme
 
@@ -47,11 +45,11 @@ Any [Announcement Types](/Announcements/Overview#announcement-types) with a `fro
 
 ### Example
 ```
-dsnp://0x1234567890abcdef/0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+dsnp://0x1234567890/0x1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 | part | value |
 | ---- | ----- |
 | Scheme | `dsnp://` |
 | User Id | `0x1234567890` |
-| Content Hash | `0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef` |
+| Content Hash | `0x1234567890abcdef0123456789abcdef0123456789abcdef0123456789abcdef` |

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,7 +5,7 @@ route: /
 
 # DSNP Specification
 
-## Version 0.9.1
+## Version 0.9.2
 
 Welcome to the Decentralized Social Networking Protocol (DSNP) specification!
 Here you can find a detailed documentation regarding the current state of the protocol, previous iterations and proposals for future extensions.


### PR DESCRIPTION
Problem
=======
Hexadecimal serialization had ambiguity in how it treated leading zeros.

Solution
========
Specified that we do NOT want any leading zeros.

with @rosalinekarr 

Change summary:
---------------
* No leading zeros in hexadecimal serialization
* Update signature examples
