### PR TITLE
Remove extra menu item

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -74,12 +74,6 @@ export default {
       ]
     },
     {
-      name: "Archivists",
-      menu: [
-        "Overview",
-      ]
-    },
-    {
       name: "Reference", menu: [
         "Glossary"
       ]


### PR DESCRIPTION
Problem
=======

Extra menu item was missed from when archivists were moved to drafts

Solution
========
Remove the extra menu item


Before:
<img width="255" alt="image" src="https://user-images.githubusercontent.com/1252199/134071316-0aa9a3e3-8ad7-4d59-8aad-8a88fc82fce0.png">


After:
<img width="252" alt="image" src="https://user-images.githubusercontent.com/1252199/134071732-7a6f2020-7471-4da9-a959-b47fa1a4c53b.png">
