### PR TITLE
fixed stale link to correct one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository holds the technical specification for the Decentralized Social Networking Protocol (DSNP).
 The current official specification can be viewed in its compiled form [here](https://spec.dsnp.org).
-Alternatively, the latest iteration of the spec can be viewed non-formatted [here](tree/main/pages).
+Alternatively, the latest iteration of the spec can be viewed non-formatted [here](https://github.com/LibertyDSNP/spec/tree/main/pages).
 For more information about the DSNP, visit [DSNP.org](https://www.dsnp.org)
 
 ## Running Locally


### PR DESCRIPTION
Problem
=======
The Readme had a link that went nowhere
[link to Pivotal Tracker #179594783](https://www.pivotaltracker.com/n/projects/2436354/stories/179594783)

Solution
========
I looked for the correct link that fit the specification listed on the readme

Change summary:
---------------
I changed the link to go to the correct page on the github repo
