### PR TITLE
colors changed in dark and header mode

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -8,7 +8,7 @@ export default {
       secondary: "#f6695d",
       accent: "#f6695d",
       header: {
-        bg: "#424242",
+        bg: "#E0E0E0",
       },
       sidebar: {
         navLinkActive: "#f6695d",
@@ -18,14 +18,14 @@ export default {
       modes: {
         dark: {
           background: "#2b2b2b",
-          primary: "#26e990",
-          secondary: "#26e990",
-          accent: "#26e990",
+          primary: "#f6695d",
+          secondary: "#f6695d",
+          accent: "#f6695d",
           header: {
             bg: "#000",
           },
           sidebar: {
-            navLinkActive: "#26e990",
+            navLinkActive: "#f6695d",
             bg: "#1c1c1c",
           },
         }


### PR DESCRIPTION
Problem
=======
Feature
[link to Pivotal Tracker ##180107617](https://www.pivotaltracker.com/story/show/180107617)
Spec branding is currently liberty branded and we want it to be DSNP branded to represent the change in URL.

Solution
========
Change logos and colors

Change summary:
---------------
* logo changed to DSNP.org
* change link color to DSNP red
* change header color to lighter gray to be able to read the logo

Steps to Verify:
----------------
1. It looks good

Screenshots (optional):
-----------------------
![Screen Shot 2021-10-27 at 3 58 24 PM](https://user-images.githubusercontent.com/43625033/139159295-2ac26064-b1ee-4a86-b7ce-12645f79aeb0.png)
![Screen Shot 2021-10-27 at 3 58 37 PM](https://user-images.githubusercontent.com/43625033/139159299-24b575c0-4dd9-444e-88c8-d9dcf46d9c7d.png)


