### PR TITLE
Correct example mistake on Attachments

### DIFF
--- a/pages/ActivityContent/Associated/Attachments.md
+++ b/pages/ActivityContent/Associated/Attachments.md
@@ -49,10 +49,12 @@ menu: Activity Content
           "type": "Link",
           "href": "https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg",
           "mediaType": "audio/ogg",
-          "hash": {
-            "algorithm": "keccak256",
-            "value": "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc"
-          }
+          "hash": [
+            {
+              "algorithm": "keccak256",
+              "value": "0x3b33df3d163e86514e9041ac97e3d920a75bbafa8d9c1489e631897874b762cc"
+            }
+          ]
         }
       ],
       "duration": "1S"
@@ -114,10 +116,12 @@ Audio objects must include a `"hash"` field as described in the [content proofs 
           "width": 350,
           "height": 228,
           "mediaType": "image/jpg",
-          "hash": {
-            "algorithm": "keccak256",
-            "value": "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5"
-          }
+          "hash": [
+            {
+              "algorithm": "keccak256",
+              "value": "0x90b3b09658ec527d679c2de983b5720f6e12670724f7e227e5c360a3510b4cb5"
+            }
+          ]
         }
       ]
     }
@@ -179,10 +183,12 @@ Audio objects must include a `"hash"` field as described in the [content proofs 
           "width": 4000,
           "height": 2250,
           "mediaType": "video/webm",
-          "hash": {
-            "algorithm": "keccak256",
-            "value": "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a"
-          }
+          "hash": [
+            {
+              "algorithm": "keccak256",
+              "value": "0xf841950dfcedc968dbd63132da844b9f28faea3dbfd4cf326b3831b419a20e9a"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Problem
=======
Hash should always be an array of values. Issue #127

Solution
========
Correct the examples to show that they are arrays.

Change summary:
---------------
* Update three examples on the Attachments page

Steps to Verify:
----------------
1. "hash" must always be shown to be an array