### PR TITLE
Changed mime types within image and audio attachments

### DIFF
--- a/pages/ActivityContent/Associated/Attachments.md
+++ b/pages/ActivityContent/Associated/Attachments.md
@@ -30,7 +30,7 @@ menu: Activity Content
 
 | Format | MIME Type    | Specification(s)                                             |
 |--------|--------------|--------------------------------------------------------------|
-| MP3    | `audio/mp3`  | [RFC3003](https://tools.ietf.org/html/rfc3003)               |
+| MP3    | `audio/mpeg`  | [RFC3003](https://tools.ietf.org/html/rfc3003)               |
 | OGG    | `audio/ogg`  | [RFC5334](https://tools.ietf.org/html/rfc5334)               |
 | WebM   | `audio/webm` | [WebM standard](https://www.webmproject.org/docs/container/) |
 
@@ -91,7 +91,6 @@ Audio objects must include a `"hash"` field as described in the [content proofs 
 | Format | MIME Type       | Specification(s)                                                 |
 |--------|-----------------|------------------------------------------------------------------|
 | JPEG   | `image/jpeg`    | [RFC2045](https://www.iana.org/go/rfc2045)                       |
-| JPG    | `image/jpg`     | [RFC2045](https://www.iana.org/go/rfc2045)                       |
 | PNG    | `image/png`     | [W3C PNG Standard](https://www.w3.org/TR/2003/REC-PNG-20031110/) |
 | SVG    | `image/svg+xml` | [W3C SVG standard](https://www.w3.org/Graphics/SVG/)             |
 | WebP   | `image/webp`    | [WebP standard](https://developers.google.com/speed/webp/)       |


### PR DESCRIPTION
Problem
=======
[Github Issue #126 ](https://github.com/LibertyDSNP/spec/issues/126)

Change summary:
---------------
- Changed the mime type of audio/mp3 -> audio/mpeg
- removed mime type of image/jpg because we have image/jpeg
Steps to Verify:
----------------
- Check that the original types are changed/removed within attachments.md


