### PR TITLE
DIP-148 Rename announcement uri

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -5,6 +5,7 @@
 # where filename is relative to this configuration file
 0.8.x.
 1.0.x
+1.1.x
 ActivityContent
 Alexa
 ArchiveEntries

--- a/.spelling
+++ b/.spelling
@@ -18,6 +18,8 @@ CODE_OF_CONDUCT
 Changelog
 CouchDB
 DAO
+DIP
+DIP-148
 DSNP
 DSNP.org
 DSNPArchives
@@ -67,6 +69,7 @@ Nonces
 OGG
 OpenZeppelin
 PNG
+pre-1
 PrivateBroadcast
 PrivateGraph
 PrivateGraphChange

--- a/pages/DSNP/Announcements.md
+++ b/pages/DSNP/Announcements.md
@@ -14,7 +14,7 @@ Implementations MUST provide a way to validate what [signatures](Signatures.md) 
 
 Each Announcement has a enumerated type for use when separating out a stream of Announcements.
 
-| Value | Name | Description | DSNP Announcement URI | Tombstone Allowed |
+| Value | Name | Description | DSNP Content URI | Tombstone Allowed |
 |------ | ---- | ----------- | --------------------- | ----------------- |
 | 0 | [Tombstone](Types/Tombstone.md) | an invalidation of another announcement | no | no |
 | 1 | [Graph Change](Types/GraphChange.md) | social graph changes | no | no |

--- a/pages/DSNP/Identifiers.md
+++ b/pages/DSNP/Identifiers.md
@@ -34,12 +34,12 @@ dsnp://1311768467294899700
 | Scheme | `dsnp://` |
 | User Id | `1311768467294899700` |
 
-## DSNP Announcement URI
+## DSNP Content URI
 
-DSNP Announcement URI consists of three parts, the scheme, the user id, and the content hash.
+DSNP Content URI consists of three parts, the scheme, the user id, and the content hash.
 It is used to uniquely identify an announcements from a given user with content.
 
-Any [Announcement Types](Announcements.md#announcement-types) with a `fromId` and `contentHash` have a DSNP Announcement URI.
+Any [Announcement Types](Announcements.md#announcement-types) with a `fromId` and `contentHash` have a DSNP Content URI.
 
 ### Example
 ```

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -1,9 +1,13 @@
 # DSNP Specification
-__Version 1.0.0__
+__Version pre-1.1.0__
 
 DSNP is a social networking protocol designed to run on a blockchain.
 It specifies an set of social primitives along with requirements for interoperability.
 Go to [Implementations](../Implementations.md) for specifics on how DSNP is implemented on a specific blockchain.
+
+## Prerelease Changelog
+
+- [DIP-148](https://github.com/LibertyDSNP/spec/issues/148) Require published for Note
 
 ## Releases
 

--- a/pages/DSNP/Types/Reaction.md
+++ b/pages/DSNP/Types/Reaction.md
@@ -1,6 +1,6 @@
 # Reaction Announcement
 
-A Reaction Announcement is for publishing emoji reactions to anything with a [DSNP Announcement URI](../Identifiers.md#dsnp-announcement-uri).
+A Reaction Announcement is for publishing emoji reactions to anything with a [DSNP Content URI](../Identifiers.md#dsnp-content-uri).
 
 ## Fields
 
@@ -10,7 +10,7 @@ A Reaction Announcement is for publishing emoji reactions to anything with a [DS
 | createdAt | milliseconds since Unix epoch | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | no
 | emoji | the encoded reaction | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | YES
 | fromId | id of the user creating the relationship | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
-| inReplyTo | Target [DSNP Announcement URI](../Identifiers.md#dsnp-announcement-uri) | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | YES
+| inReplyTo | Target [DSNP Content URI](../Identifiers.md#dsnp-content-uri) | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | YES
 | signature | creator signature | 65 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | no
 
 ## Field Requirements
@@ -49,7 +49,7 @@ None of the following should be considered valid:
 
 ### inReplyTo
 
-- MUST be a [DSNP Announcement URI](../Identifiers.md#dsnp-announcement-uri)
+- MUST be a [DSNP Content URI](../Identifiers.md#dsnp-content-uri)
 
 ### signature
 

--- a/pages/DSNP/Types/Reply.md
+++ b/pages/DSNP/Types/Reply.md
@@ -1,7 +1,7 @@
 # Reply Announcement
 
 A Reply Announcement is the same as a [Broadcast Announcement](../Types/Broadcast.md),
-but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Announcement URI](../Identifiers.md#dsnp-announcement-uri).
+but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Content URI](../Identifiers.md#dsnp-content-uri).
 
 ## Fields
 
@@ -11,7 +11,7 @@ but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Anno
 | contentHash | keccak-256 hash of content stored at URL | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | createdAt | milliseconds since Unix epoch | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | no
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
-| inReplyTo | Target [DSNP Announcement URI](../Identifiers.md#dsnp-announcement-uri) | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | YES
+| inReplyTo | Target [DSNP Content URI](../Identifiers.md#dsnp-content-uri) | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | YES
 | url | content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
 | signature | creator signature | 65 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | no
 
@@ -36,7 +36,7 @@ but includes an `inReplyTo` field for noting it as a reply to a given [DSNP Anno
 
 ### inReplyTo
 
-- MUST be a [DSNP Announcement URI](../Identifiers.md#dsnp-announcement-uri)
+- MUST be a [DSNP Content URI](../Identifiers.md#dsnp-content-uri)
 
 ### url
 

--- a/pages/Draft/Archivists.md
+++ b/pages/Draft/Archivists.md
@@ -2,7 +2,7 @@
 
 The job of an Archivist is to permanently store Batch content and DSNP Announcements in a format that is easily validated and retrieved.
 
-The Archivist must be able to access chain data and all DSNP Announcement URLs.
+The Archivist must be able to access chain data and all DSNP Content.
 
 ## Validations that Archivists could perform
 

--- a/pages/Ethereum/Overview.md
+++ b/pages/Ethereum/Overview.md
@@ -24,4 +24,4 @@ Official DSNP interfaces, contracts, and deployment information may be found in 
 
 | Version | Description | DSNP Compatibility | Release Date | Changelog |
 | --- | --- | --- | --- | --- |
-| [1.0.0](https://github.com/LibertyDSNP/spec/tree/EVM-v1.0.0) | Initial Release | 1.0.x | 2021-09-09 | [Changelog](https://github.com/LibertyDSNP/spec/releases/tag/EVM-v1.0.0) |
+| [1.0.0](https://github.com/LibertyDSNP/spec/tree/EVM-v1.0.0) | Initial Release | 1.0.x, 1.1.x | 2021-09-09 | [Changelog](https://github.com/LibertyDSNP/spec/releases/tag/EVM-v1.0.0) |


### PR DESCRIPTION
Problem
=======
While updating https://github.com/LibertyDSNP/spec/issues/145, we realized that the DSNP Announcement URI is a misnomer. It is instead a Content URI and should be identified as such in the spec.

Link to GitHub Issue(s): Closes #148 

Solution
========
Renamed DSNP Announcement URI to DSNP Content URI

Change summary:
---------------
- [x] Updated Spec Versions
- [x] Change name everywhere

Steps to Verify:
----------------
1. Search for DSNP Announcement URI
1. Don't find it or any variations

