### PR TITLE
DIP-158 Require Published field on Activity Content type Note

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -21,6 +21,7 @@ CouchDB
 DAO
 DIP
 DIP-148
+DIP-158
 DSNP
 DSNP.org
 DSNPArchives
@@ -158,6 +159,7 @@ namespace
 objectId
 parseable
 permissioned
+pre-1
 prepended
 prosumer
 punycode

--- a/pages/ActivityContent/Overview.md
+++ b/pages/ActivityContent/Overview.md
@@ -1,5 +1,5 @@
 # Activity Content Specification
-__Version 1.0.0__
+__Version pre-1.1.0__
 
 Content references shared via the DSNP consists of URLs pointing to documents containing Activity Streams JSON objects.
 For the purposes of the DSNP, restrictions are placed on the [Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) specification.
@@ -44,6 +44,10 @@ URLs in DSNP-compatible Activity Content MUST to use one of the following URL sc
 | [LibertyDSNP/activity-content](https://github.com/LibertyDSNP/activity-content) | JavaScript/TypeScript |
 | [LibertyDSNP/activity-content-java](https://github.com/LibertyDSNP/activity-content-java) | Java/Kotlin |
 | [LibertyDSNP/activity-content-swift](https://github.com/LibertyDSNP/activity-content-swift) | Swift |
+
+## Prerelease Changelog
+
+- [DIP-158](https://github.com/LibertyDSNP/spec/issues/158)
 
 ## Releases
 

--- a/pages/ActivityContent/Types/Note.md
+++ b/pages/ActivityContent/Types/Note.md
@@ -8,8 +8,8 @@
 | `type` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-type) | YES | Identifies the type of the object | MUST be set to `Note` |
 | `content` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-content) | YES | Text content of the note |  |
 | `mediaType` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-mediatype) | YES | MIME type for the `content` field | MUST be set to a [supported MIME type](#supported-content-mime-types) |
+| `published` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-published) | YES | The time of publishing | MUST be [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | `name` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-name) | no | The display name for the note |  |
-| `published` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-published) | no | The time of publishing | MUST be [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
 | `attachment` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-attachment) | no | Array of attached links or media | MUST be one of the [Supported Attachments](../Associated/Attachments.md) |
 | `tag` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-tag) | no | Array of tags/mentions | MUST follow [Tag Type](../Associated/Tag.md) |
 | `location` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-location) | no | For location | MUST follow [Location Type](../Associated/Location.md) |


### PR DESCRIPTION
Problem
=======

While updating #145 and then #148 we realized that content hashes should be "required" to be unique, achievable via making the published field required.

Link to GitHub Issue(s): Closes #158

Solution
========
Marked `published` as required

Change summary:
---------------
- [x] Updated Spec Versions
- [x] Update `published`

Screenshots (optional):
-----------------------
<img width="786" alt="image" src="https://user-images.githubusercontent.com/1252199/161838980-436e8a72-66b8-488b-a587-d55e5dd3f5d4.png">
