### PR TITLE
fix deployment spec

### DIFF
--- a/.github/workflows/mdbook_cd.yml
+++ b/.github/workflows/mdbook_cd.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Deploy mdBook to github pages 🚀
         uses: peaceiris/actions-gh-pages@v3
         with:
-          folder: ./book
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book

--- a/.github/workflows/mdbook_ci.yml
+++ b/.github/workflows/mdbook_ci.yml
@@ -39,11 +39,11 @@ jobs:
         run: mdbook build
 
       - name: Create tarball 📦
-        if: ${{ github.ref == 'refs/heads/main' }}
+        #if: ${{ github.ref == 'refs/heads/main' }}
         run: tar -cvf spec_mdbook.tar ./book
 
       - name: Create mdbook build artifact 📦
-        if: ${{ github.ref == 'refs/heads/main' }}
+        #if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v3
         with:
           name: spec_mdbook-${{ github.sha }}

--- a/.github/workflows/mdbook_ci.yml
+++ b/.github/workflows/mdbook_ci.yml
@@ -39,11 +39,11 @@ jobs:
         run: mdbook build
 
       - name: Create tarball 📦
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: tar -cvf spec_mdbook.tar ./book
 
       - name: Create mdbook build artifact 📦
-        #if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v3
         with:
           name: spec_mdbook-${{ github.sha }}


### PR DESCRIPTION
Problem
=======
The trigger works and deployment is able to pick the correct artifacts, following things remain
- [x] update deployment spec to use correct mdbook action to gh-pages

Solution
========
Update following https://github.com/peaceiris/actions-gh-pages for mdbook need to specify 
- [x] Token which is not a PAT token but one auto generated by action itself
- [x] publish_dir is book 


Change summary:
---------------
- [x] Token which is not a PAT token but one auto generated by action itself
- [x] publish_dir is book 

Steps to Verify:
----------------
1. Since workflow runs and able to pick tagged artifacts for specific commits we are almost there
2. After this PR I will run a deployment to see if gh-pages are generated

