### PR TITLE
fixed external link sidebar

### DIFF
--- a/theme/css/chrome.css
+++ b/theme/css/chrome.css
@@ -500,3 +500,7 @@ ul#searchresults span.teaser em {
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
 }
+
+.nav-return:hover {
+    color: var(--sidebar-active);
+}

--- a/theme/css/general.css
+++ b/theme/css/general.css
@@ -180,3 +180,9 @@ blockquote {
 .result-no-output {
     font-style: italic;
 }
+
+.nav-return,
+.nav-return:visited {
+    color: var(--searchbar-fg);
+    text-decoration: none;
+}

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -107,7 +107,7 @@
                     <img src="{{ path_to_root }}images/DSNP_Logo.png" alt="The DSNP Logo" width="123" height="55"/> 
                 </a>
                 {{#toc}}{{/toc}}
-                <a href="https://www.dsnp.org/developer-portal/" class="css-qxltjf">↩ Developer Portal</a>
+                <a href="https://www.dsnp.org/developer-portal/" class="nav-return">↩ Developer Portal</a>
             </div>
             <div id="sidebar-resize-handle" class="sidebar-resize-handle"></div>
         </nav>


### PR DESCRIPTION
Problem
=======
External links in the sidebar (i.e. Developer Portal) should have the same formatting as the other items
issue (https://github.com/LibertyDSNP/spec/issues/155)

Change summary:
---------------
- fixed css on sidebar

Screenshots (optional):
-----------------------
![Screen Shot 2022-04-11 at 6 04 25 PM](https://user-images.githubusercontent.com/9152501/162858516-81caa820-2214-4386-86e9-74ef960af0cb.png)

