### PR TITLE
Update Announcement Type for DIP-165

### DIFF
--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -83,7 +83,6 @@
     "blocklists",
     "changeType",
     "contentHash",
-    "createdAt",
     "deadDropID",
     "dequeued",
     "deserialized",

--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -113,7 +113,7 @@
     "namespace",
     "objectId",
     "officiation",
-    "contentURI",
+    "targetContentHash",
     "parseable",
     "permissioned",
     "prepended",

--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -113,7 +113,7 @@
     "namespace",
     "objectId",
     "officiation",
-    "oldUrl",
+    "contentURI",
     "parseable",
     "permissioned",
     "prepended",

--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -83,6 +83,7 @@
     "blocklists",
     "changeType",
     "contentHash",
+    "createdAt",
     "deadDropID",
     "dequeued",
     "deserialized",

--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -113,6 +113,7 @@
     "namespace",
     "objectId",
     "officiation",
+    "oldUrl",
     "parseable",
     "permissioned",
     "prepended",

--- a/pages/DSNP/Announcements.md
+++ b/pages/DSNP/Announcements.md
@@ -37,7 +37,7 @@ Additional duplicate Announcements MUST be rejected or ignored.
 
 ## Reverting an Announcement
 
-Announcements may not be deleted, but some may be marked as invalid by using a [Tombstone Announcement](Types/Tombstone.md).
+Announcements may not be deleted, but some may be marked as invalid by using a [Tombstone Announcement](Types/Tombstone.md), or updated by using an [Update Announcement](Types/Update.md).
 For example, if a user creates a Reaction Announcement, they may remove that reaction by creating a Tombstone Announcement.
 
 ## Non-Normative

--- a/pages/DSNP/Announcements.md
+++ b/pages/DSNP/Announcements.md
@@ -22,6 +22,7 @@ Each Announcement has an enumerated type for use when separating out a stream of
 | 3 | [Reply](Types/Reply.md) | a public response to a Broadcast | YES | YES |
 | 4 | [Reaction](Types/Reaction.md) | a public visual reply to a Broadcast | no | no |
 | 5 | [Profile](Types/Profile.md) | a profile | YES | no |
+| 6 | [Update](Types/Update.md) | an update to content| YES | no |
 
 ## Duplicate Handling
 
@@ -38,7 +39,6 @@ Additional duplicate Announcements MUST be rejected or ignored.
 
 Announcements may not be deleted, but some may be marked as invalid by using a [Tombstone Announcement](Types/Tombstone.md).
 For example, if a user creates a Reaction Announcement, they may remove that reaction by creating a Tombstone Announcement.
-
 
 ## Non-Normative
 

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -10,6 +10,7 @@ Go to [Implementations](../Implementations.md) for specifics on how DSNP is impl
 - [DIP-148](https://github.com/LibertyDSNP/spec/issues/148) Require published for Note
 - [DIP-149](https://github.com/LibertyDSNP/spec/issues/149) Reaction retraction
 - [DIP-180](https://github.com/LibertyDSNP/spec/issues/180) Tombstones target content hashes instead of signatures
+- [DIP-165](https://github.com/LibertyDSNP/spec/issues/165) Update Announcements
 
 ## Releases
 

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -12,7 +12,7 @@ announced content.
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
-| oldUrl | URL of old content | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
+| contentURI | URL of old content | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
 
 ## Field Requirements
 
@@ -39,7 +39,7 @@ announced content.
 - Resource MUST one of the supported [Activity Content](../../ActivityContent/Overview.md) Types
 - MUST use one of the supported URL Schemes
 
-### oldUrl
+### contentURI
 
 - All above points for urls apply
 - MUST only point to Broadcast or Reply Announcements

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -12,6 +12,7 @@ announced content.
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
+| oldUrl | URL of old content | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
 
 ## Field Requirements
 
@@ -37,3 +38,8 @@ announced content.
 - MUST NOT refer to localhost or any reserved IP addresses as defined in [RFC6890](https://datatracker.ietf.org/doc/html/rfc6890)
 - Resource MUST one of the supported [Activity Content](../../ActivityContent/Overview.md) Types
 - MUST use one of the supported URL Schemes
+
+### oldUrl
+
+- All above points for urls apply
+- MUST only point to Broadcast or Reply Announcements

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -9,7 +9,6 @@ Updates should be ignored.
 | Field | Description | Data Type | Serialization | Parquet Type | Bloom Filter |
 | ----- | ----------- | --------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`6`) | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
-| createdAt | milliseconds since Unix epoch | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | no
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
@@ -20,10 +19,6 @@ Updates should be ignored.
 ### announcementType
 
 - MUST be fixed to `6`
-
-### createdAt
-
-- MUST be set to the milliseconds since Unix epoch at time of signing
 
 ### fromId
 

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -1,7 +1,8 @@
 # Update Announcement
 
 An Update Announcement is a way to note intent to update previously
-announced content.
+announced content. If the original Broadcast/Reply is Tombstoned, subsequent
+Updates should be ignored.
 
 ## Fields
 

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -1,0 +1,45 @@
+# Update Announcement
+
+An Update Announcement is a way to note intent to update previously
+announced content.
+
+## Fields
+
+| Field | Description | Data Type | Serialization | Parquet Type | Bloom Filter |
+| ----- | ----------- | --------- | ------------- | ------------ | ------------ |
+| announcementType | Announcement Type Enum (`6`) | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
+| createdAt | milliseconds since Unix epoch | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | no
+| fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
+| contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
+| url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
+| signature | creator signature | 65 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | no
+
+## Field Requirements
+
+### announcementType
+
+- MUST be fixed to `0`
+
+### createdAt
+
+- MUST be set to the milliseconds since Unix epoch at time of signing
+
+### fromId
+
+- MUST be a [DSNP User Id](../Identifiers.md#dsnp-user-id)
+- MUST be the [signer](../Signatures.md) of the target announcement
+
+### contentHash
+
+- MUST be the [keccak-256 hash](https://keccak.team/files/Keccak-submission-3.pdf) of the bytes of the reference at the url
+
+### url
+
+- MUST NOT refer to localhost or any reserved IP addresses as defined in [RFC6890](https://datatracker.ietf.org/doc/html/rfc6890)
+- Resource MUST one of the supported [Activity Content](../../ActivityContent/Overview.md) Types
+- MUST use one of the supported URL Schemes
+
+### signature
+
+- MUST be an [Announcement Signature](../Signatures.md) over the all fields except this signature field
+- MUST be the signature of the `fromId` user

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -12,7 +12,6 @@ announced content.
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
-| signature | creator signature | 65 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | no
 
 ## Field Requirements
 
@@ -38,8 +37,3 @@ announced content.
 - MUST NOT refer to localhost or any reserved IP addresses as defined in [RFC6890](https://datatracker.ietf.org/doc/html/rfc6890)
 - Resource MUST one of the supported [Activity Content](../../ActivityContent/Overview.md) Types
 - MUST use one of the supported URL Schemes
-
-### signature
-
-- MUST be an [Announcement Signature](../Signatures.md) over the all fields except this signature field
-- MUST be the signature of the `fromId` user

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -28,7 +28,6 @@ Updates should be ignored.
 ### fromId
 
 - MUST be a [DSNP User Id](../Identifiers.md#dsnp-user-id)
-- MUST be the [signer](../Signatures.md) of the target announcement
 
 ### contentHash
 

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -18,7 +18,7 @@ announced content.
 
 ### announcementType
 
-- MUST be fixed to `0`
+- MUST be fixed to `6`
 
 ### createdAt
 

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -12,7 +12,7 @@ announced content.
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
-| contentURI | URL of old content | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
+| targetContentHash | keccak-256 hash of target content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 
 ## Field Requirements
 
@@ -39,7 +39,6 @@ announced content.
 - Resource MUST one of the supported [Activity Content](../../ActivityContent/Overview.md) Types
 - MUST use one of the supported URL Schemes
 
-### contentURI
+### targetContentHash
 
-- All above points for urls apply
-- MUST only point to Broadcast or Reply Announcements
+- MUST be the [keccak-256 hash](https://keccak.team/files/Keccak-submission-3.pdf) of the bytes of the reference at the url

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -36,4 +36,11 @@ Updates should be ignored.
 
 ### targetContentHash
 
-- MUST be the [keccak-256 hash](https://keccak.team/files/Keccak-submission-3.pdf) of the bytes of the reference at the url
+- MUST be the `contentHash` of an allowed Announcement type with the same `fromId` as the Update Announcement
+
+#### Update Allowed Announcement Types
+
+| Value | Name |
+|------ | ---- |
+| 2 | [Broadcast](../Types/Broadcast.md) |
+| 3 | [Reply](../Types/Reply.md) |

--- a/pages/SUMMARY.md
+++ b/pages/SUMMARY.md
@@ -14,6 +14,7 @@
         - [Reply](DSNP/Types/Reply.md)
         - [Reaction](DSNP/Types/Reaction.md)
         - [Profile](DSNP/Types/Profile.md)
+        - [Update](DSNP/Types/Update.md)
     - [Serializations](DSNP/Serializations.md)
 - [DSNP Implementation Specs](Implementations.md)
     - [EVM](Ethereum/Overview.md)


### PR DESCRIPTION
Problem
=======
This PR adds an Update Announcement type to the DSNP spec.

Link to GitHub Issue(s):
#165 

Solution
========
The Update Announcement has a contentHash that is a keccak-256 hash of the _new, updated_ content. It also has a URL that points to the new content.

Discussion
========
Open question: will we need to create a new URL each time we update content?

Diagram:
<img width="863" alt="Screen Shot 2022-04-18 at 3 57 39 PM" src="https://user-images.githubusercontent.com/3819564/163890180-e1ada199-7572-4b1d-813b-890816f99a3d.png">

One scenario is as follows: a user emits a Broadcast, creating new content. The Broadcast Announcement contains a hash of the content as well as a URL that points to that content.

Later on, the user decides that they want to update said content. They emit an Update Announcement that contains a new hash of the updated content but the same URL as the original broadcast. This means the previous Broadcast's content hash will no longer be valid, even if it was valid at the time it was created.

Does this matter?

The upside of this approach is that we will be able to host content once and then point updates to that single hosted copy. The downside is that previous content hashes will be invalidated each time an update is made.

-------

Consider another scenario: the user emits a Broadcast creating content as earlier and tries to update it. This time, however, a new URL is created that points to either a brand new copy of the updated content, or some sort of diff.

Diagram:
<img width="846" alt="Screen Shot 2022-04-18 at 4 00 51 PM" src="https://user-images.githubusercontent.com/3819564/163890461-8512df68-bdfd-4dd7-a940-97e3fd81ff5b.png">

The upside of this approach is not only that the all content has a traceable history, but also that previous versions can be validated. However, the downside is that we will wither have to copy content on each update or rely on clients to piece together partial diffs.

**I think that until we have a compelling reason not to, we should take the 2nd approach.**