### PR TITLE
removed missing links

### DIFF
--- a/pages/ActivityContent/Associated/Attachments.md
+++ b/pages/ActivityContent/Associated/Attachments.md
@@ -80,7 +80,6 @@
 | `height` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-height) | no | A hint as to the rendering height in device-independent pixels |  |
 | `width` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-width) | no | A hint as to the rendering width in device-independent pixels |  |
 
-Audio objects must include a `"hash"` field as described in the [content proofs section](#content-proofs) below.
 
 ### Supported Image MIME Types
 
@@ -146,7 +145,6 @@ Audio objects must include a `"hash"` field as described in the [content proofs 
 | `height` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-height) | no | A hint as to the rendering height in device-independent pixels |  |
 | `width` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-width) | no | A hint as to the rendering width in device-independent pixels |  |
 
-Audio objects must include a `"hash"` field as described in the [content proofs section](#content-proofs) below.
 
 ### Supported Video MIME Types
 


### PR DESCRIPTION
Problem
=======
There's a missing section (content-proof) in the Attachments page right after the Video Link table.
See /pages/ActivityContent/Associated/Attachments.md for [content proofs section] link
https://github.com/LibertyDSNP/spec/issues/152

Solution
========
After checking the missing section [here](https://github.com/LibertyDSNP/spec/blob/ee90c0b02d2bc5e75fde00279832847ca099436e/pages/ActivityStreams/Overview.md#content-proofs) is looks like that the `content-proof` section is evolved into `Associated Type: Hash` and I think removing these left-over links will solve this issue.

