### PR TITLE
put mdbook artifacts in root folder

### DIFF
--- a/.github/workflows/mdbook_cd.yml
+++ b/.github/workflows/mdbook_cd.yml
@@ -27,4 +27,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
+          publish_dir: ./book/html

--- a/.github/workflows/mdbook_cd.yml
+++ b/.github/workflows/mdbook_cd.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Decompress mdbook build artifact 📦
         run: mkdir book && tar -xvf spec_mdbook-${{ github.sha }}/spec_mdbook.tar ./book && ls ./book
 
-      - name: Deploy mdBook to github pages 🚀
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book/html
+          branch: gh-pages
+          folder: .book/html


### PR DESCRIPTION
Problem
=======
Mdbook produces artifacts in book/html folder which when dumped to gh-pages wont abide by setting that index.html reside in root folder
Link to GitHub Issue(s): https://github.com/LibertyDSNP/spec/issues/178
Solution
========
Updating deployment workflow to use the the static page artifacts in sub-directory of book generated by mdbook to gh-pages directory

Change summary:
---------------
- [ ] Updated mdbook_cd workflow with this fix

Steps to Verify:
----------------
1. Only way to verify would be to run the deployment and ensure we have all artifacts in root folder of gh-pages

