### PR TITLE
Tombstone should target contentHash for DIP-180

### DIFF
--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -133,7 +133,7 @@
     "stringify",
     "subreddit",
     "targetAnnouncementType",
-    "targetSignature",
+    "targetContentHash",
     "testnet",
     "timestamp",
     "timestamps",

--- a/pages/DSNP/Announcements.md
+++ b/pages/DSNP/Announcements.md
@@ -16,13 +16,12 @@ Each Announcement has an enumerated type for use when separating out a stream of
 
 | Value | Name | Description | DSNP Content URI | Tombstone Allowed |
 |------ | ---- | ----------- | --------------------- | ----------------- |
-| 0 | [Tombstone](Types/Tombstone.md) | an invalidation of another announcement | no | no |
+| 0 | [Tombstone](Types/Tombstone.md) | an invalidation of previously announced content | no | no |
 | 1 | [Graph Change](Types/GraphChange.md) | social graph changes | no | no |
 | 2 | [Broadcast](Types/Broadcast.md) | a public post | YES | YES |
 | 3 | [Reply](Types/Reply.md) | a public response to a Broadcast | YES | YES |
 | 4 | [Reaction](Types/Reaction.md) | a public visual reply to a Broadcast | no | YES |
 | 5 | [Profile](Types/Profile.md) | a profile | YES | no |
-
 
 ## Duplicate Handling
 

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -9,6 +9,7 @@ Go to [Implementations](../Implementations.md) for specifics on how DSNP is impl
 
 - [DIP-148](https://github.com/LibertyDSNP/spec/issues/148) Require published for Note
 - [DIP-149](https://github.com/LibertyDSNP/spec/issues/149) Reaction retraction
+- [DIP-180](https://github.com/LibertyDSNP/spec/issues/180) Tombstones target content hashes instead of signatures
 
 ## Releases
 

--- a/pages/DSNP/Types/Tombstone.md
+++ b/pages/DSNP/Types/Tombstone.md
@@ -1,6 +1,6 @@
 # Tombstone Announcement
 
-A Tombstone Announcement is a way to note that a previous Announcement signature is invalid and the related Announcement should be considered reverted.
+A Tombstone Announcement is a way to note that a previously announced content is invalid and the related Announcement should be considered reverted.
 It is NOT possible to revert a tombstone.
 
 ## Fields
@@ -11,7 +11,7 @@ It is NOT possible to revert a tombstone.
 | createdAt | milliseconds since Unix epoch | 64-bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | no
 | fromId | id of the user creating the Announcement and the Tombstoned Announcement | 64-bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | targetAnnouncementType | target tombstoned Announcement type | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
-| targetSignature | target Announcement Signature to tombstone | 65 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
+| targetContentHash | target `contentHash` of the original Announcement to tombstone | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | signature | creator signature | 65 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | no
 
 ## Field Requirements
@@ -31,8 +31,8 @@ It is NOT possible to revert a tombstone.
 
 ### targetAnnouncementType
 
-- MUST be the [Announcement Type](../Announcements.md#announcement-types) of the Target Announcement
-- MUST ONLY be a Tombstone Allowed Announcement Type
+- MUST be the [Announcement Type](../Announcements.md#announcement-types) of the target Announcement
+- MUST ONLY be a Tombstone allowed Announcement Type
 
 #### Tombstone Allowed Announcement Types
 
@@ -40,11 +40,10 @@ It is NOT possible to revert a tombstone.
 |------ | ---- |
 | 2 | [Broadcast](../Types/Broadcast.md) |
 | 3 | [Reply](../Types/Reply.md) |
-| 4 | [Reaction](../Types/Reaction.md) |
 
-### targetSignature
+### targetContentHash
 
-- MUST be an [Announcement Signature](../Signatures.md) that the `fromId` has announced
+- MUST match a `contentHash` of previous Announcement with the same `fromId` as the Tombstone Announcement
 
 ### signature
 


### PR DESCRIPTION
Problem
=======
Signatures are going away with DIP-#145 and we needed to have Tombstones use something else.

Link to GitHub Issue(s): DIP-#180 

Solution
========
Altered the Tombstone spec to target contentHash

Change summary:
---------------
- [x] Updated Spec Versions
- [x] Made changes for the Announcements.md page
- [x] Made changes to the Tombstones.md page


Steps to Verify:
----------------
1. No more targetSignature

Screenshots (optional):
-----------------------
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/1252199/164496238-c1b915e0-2a7c-4bb9-a6ff-f34854278b70.png">
