### PR TITLE
Proposed changes for DIP-216

### DIFF
--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -1,16 +1,15 @@
 # DSNP Specification
-__Version 1.1.0__
+__Version pre-1.2.0__
 
 DSNP is a social networking protocol designed to run on a blockchain.
 It specifies a set of social primitives along with requirements for interoperability.
 Go to [Implementations](../Implementations.md) for specifics on how DSNP is implemented on a specific blockchain.
 
-<!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]`
+<!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]` --->
 ## Prerelease Changelog
 
-- [DIP-###](https://github.com/LibertyDSNP/spec/issues/###)
+- [DIP-216](https://github.com/LibertyDSNP/spec/issues/216)
 
---->
 ## Releases
 
 Implementations MUST specify the version(s) of the DSNP specification with which they are compatible.

--- a/pages/DSNP/Types/Update.md
+++ b/pages/DSNP/Types/Update.md
@@ -12,6 +12,7 @@ Updates should be ignored.
 | fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | contentHash | keccak-256 hash of updated content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 | url | updated content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
+| targetAnnouncementType | target updated Announcement type | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
 | targetContentHash | keccak-256 hash of target content | 32 bytes | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
 
 ## Field Requirements
@@ -34,9 +35,10 @@ Updates should be ignored.
 - Resource MUST be one of the supported [Activity Content](../../ActivityContent/Overview.md) Types
 - MUST use one of the supported URL Schemes
 
-### targetContentHash
+### targetAnnouncementType
 
-- MUST be the `contentHash` of an allowed Announcement type with the same `fromId` as the Update Announcement
+- MUST be the [Announcement Type](../Announcements.md#announcement-types) of the target Announcement
+- MUST ONLY be an Update allowed Announcement Type
 
 #### Update Allowed Announcement Types
 
@@ -44,3 +46,7 @@ Updates should be ignored.
 |------ | ---- |
 | 2 | [Broadcast](../Types/Broadcast.md) |
 | 3 | [Reply](../Types/Reply.md) |
+
+### targetContentHash
+
+- MUST be the `contentHash` of an allowed Announcement type with the same `fromId` as the Update Announcement


### PR DESCRIPTION
Problem
=======
Update Announcements should have a `targetAnnouncementType`.
Link to GitHub Issue(s): #216 

Solution
========
Add to table and list of fields for Update Announcement.

Change summary:
---------------
- [ ] Edited the Update Announcement page
- [ ] Updated spec version to pre-1.2.0

Steps to Verify:
----------------
1. Generate site and review for layout and content
