### PR TITLE
DIP-220 Identifier retirement

### DIFF
--- a/.yaspellerrc.json
+++ b/.yaspellerrc.json
@@ -107,7 +107,7 @@
     "testnet",
     "timestamp[s]?",
     "toAddress",
-    "tombstoned",
+    "tombston(ed|ing)",
     "unencrypted",
     "unfollow(s|ed|ing)?",
     "unicode",

--- a/pages/DSNP/Identity.md
+++ b/pages/DSNP/Identity.md
@@ -16,7 +16,7 @@ The [social graph](Graph.md) is formed using this Identifier so that a user's co
 ## Ownership
 
 A user's ownership of their identity is expressed via ownership and control of their pseudo-anonymous Identifier(s).
-Control entails the power to invoke DSNP Operations including publishing announcements that create, update and delete (tombstone) content associated with the Identifier, delegating these powers to others, and managing keys associated with the Identifier.
+Control entails the power to invoke DSNP Operations including publishing [Announcements](Announcements.md) that create, update and delete (Tombstone) content associated with the Identifier, [delegating](#delegation) these powers to others, [managing keys](#key-management) associated with the Identifier, and [retiring](#retirement) the Identifier.
 
 ### Key Management
 
@@ -24,6 +24,15 @@ An initial control key must be created in order to acquire an Identifier.
 Each distinct Identifier MUST have distinct control keys; that is, the same key MUST NOT be linked to multiple Identifiers.
 Optionally, an implementation MAY allow the user to add and remove additional keys.
 An implementation MUST NOT allow the user to remove the only or last remaining control key.
+
+### Retirement
+
+A user may choose to retire their Identifier at any time.
+Once an Identifier is retired, an implementation MAY remove all state data associated with that Identifier, provided that an indication that the Identifier is retired remains, so it may not be reused in the future.
+This means that all data previously sent from the Identifier, the keys associated with the Identifier, and the delegations (see next section) associated with the Identifier may be removed.
+
+After an Identifier is retired, any existing or future [Announcements](Announcements.md) from the Identifier should be treated as if they have been [tombstoned](Types/Tombstone.md) (for Announcement Types that support tombstoning).
+A retired Identifier MUST NOT be allowed to act as a principal for any additional DSNP [Operations](Operations.md).
 
 ### Delegation
 
@@ -35,6 +44,7 @@ An implementation MUST NOT allow the user to remove the only or last remaining c
 ## Related Operations
 
 * [Create Identifier](Operations.md#create-identifier)
+* [Retire Identifier](Operations.md#retire-identifier)
 * [Define Delegation](Operations.md#define-delegation)
 * [Revoke Delegation](Operations.md#revoke-delegation)
 * [Add Control Key](Operations.md#add-control-key)

--- a/pages/DSNP/Operations.md
+++ b/pages/DSNP/Operations.md
@@ -27,6 +27,7 @@ Compliant implementations may respond to error conditions either synchronously, 
 | Operation | Optional? | Principal(s) | Inputs | State Change Record |
 |---------- |---------- |------------- |------- |-------------- |
 | <a id="create-identifier">Create Identifier</a> | no | None | Control Key, Control Key Ownership Proof | [Identifier Creation Record](Records.md#identifier-creation) |
+| <a id="retire-identifier">Retire Identifier</a> | no | User | None | [Identifier Retirement Record](Records.md#identifier-retirement) |
 | <a id="define-delegation">Define Delegation</a> | no | User AND Delegate | User's Identifier, Delegate's Identifier, Set of Allowed [Announcement Types](Announcements.md#announcement-types) | [Delegation Definition Record](Records.md#delegation-definition) |
 | <a id="revoke-delegation">Revoke Delegation</a> | no | User OR Delegate | User's Identifier, Delegate's Identifier | [Delegation Revocation Record](Records.md#delegation-revocation) |
 | <a id="add-control-key">Add Control Key</a> | YES | User | Key, Key Ownership Proof | [Control Key Addition Record](Records.md#control-key-addition) |

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -33,6 +33,7 @@ A compliant implementation MUST specify a mapping from its implementation-specif
 ## Prerelease Changelog
 
 - [DIP-216](https://github.com/LibertyDSNP/spec/issues/216)
+- [DIP-220](https://github.com/LibertyDSNP/spec/issues/220)
 
 ## Releases
 

--- a/pages/DSNP/Records.md
+++ b/pages/DSNP/Records.md
@@ -32,6 +32,12 @@ Records consists of one or more fields.
 </tr>
 
 <tr>
+<td rowspan="1"><a id="identifier-retirement">Identifier Retirement Record</a></td>
+<td>User's Identifier</td>
+<td><a href="Identifiers.html#dsnp-user-id">DSNP User Id</a></td>
+</tr>
+
+<tr>
 <td rowspan="3"><a id="delegation-definition">Delegation Definition Record</a></td>
 <td>User Id</td>
 <td><a href="Identifiers.html#dsnp-user-id">DSNP User Id</a></td>


### PR DESCRIPTION
Problem
=======
Per #220, retiring a user identifier is an important aspect of user control.

Solution
========
Add a Retire Identifier Operation and corresponding State Change Record. A description of the rationale and implications of identifier retirement is also added to the Identity page.

Change summary:
---------------
- [ ] Added discussion to Identity page
- [ ] Updated Operations and State Change Records

Steps to Verify:
----------------
1. Generate and review site.
