### PR TITLE
Cleanup whitespace and align data columns

### DIFF
--- a/pages/ActivityContent/Associated/Hash.md
+++ b/pages/ActivityContent/Associated/Hash.md
@@ -23,7 +23,7 @@ This example gives SHA-256 and BLAKE2b hashes for the [PDF version of the DSNP w
 {
   "hash": [
     "QmQNHNfHnbgJJ6nK4UPx2VtTUCafAKCbqZJ6ZRYUGjoeFj",
-	  "2DrjgbGgSsXRhTiBWckoVwBFC6H4qiBWWNumSsRwdUt82YnTdN"
+    "2DrjgbGgSsXRhTiBWckoVwBFC6H4qiBWWNumSsRwdUt82YnTdN"
   ]
 }
 ```

--- a/pages/ActivityContent/Associated/Hash.md
+++ b/pages/ActivityContent/Associated/Hash.md
@@ -23,7 +23,7 @@ This example gives SHA-256 and BLAKE2b hashes for the [PDF version of the DSNP w
 {
   "hash": [
     "QmQNHNfHnbgJJ6nK4UPx2VtTUCafAKCbqZJ6ZRYUGjoeFj",
-	"2DrjgbGgSsXRhTiBWckoVwBFC6H4qiBWWNumSsRwdUt82YnTdN"
+	  "2DrjgbGgSsXRhTiBWckoVwBFC6H4qiBWWNumSsRwdUt82YnTdN"
   ]
 }
 ```

--- a/pages/DSNP/Announcements.md
+++ b/pages/DSNP/Announcements.md
@@ -82,7 +82,7 @@ User-generated timestamps cannot be validated, but may be used to indicate order
 ### Announcement Reference Ordering
 
 Some Announcements contain references to other Announcements via the `inReplyTo` field.
-Due to the distributed nature of DSNP, the canonical order can have an Announcement that refers to another announcement appearing later in the network order.
+Due to the distributed nature of DSNP, the canonical order can have an Announcement that refers to another Announcement appearing later in the network order.
 For display purposes, these messages should be considered to have occurred after the reference.
 
 ### DSNP v1.0 Announcement Signatures

--- a/pages/DSNP/Identifiers.md
+++ b/pages/DSNP/Identifiers.md
@@ -37,7 +37,7 @@ dsnp://1311768467294899700
 ## DSNP Content URI
 
 The DSNP Content URI consists of three parts: the scheme, the user id, and the content hash.
-It is used to uniquely identify an announcement from a given user with content.
+It is used to uniquely identify an Announcement from a given user with content.
 
 Any [Announcement Types](Announcements.md#announcement-types) with a `fromId` and `contentHash` have a DSNP Content URI.
 

--- a/pages/DSNP/Identity.md
+++ b/pages/DSNP/Identity.md
@@ -38,7 +38,7 @@ A retired Identifier MUST NOT be allowed to act as a principal for any additiona
 
 * An owner MUST be able to delegate permission to announce on their behalf to other parties.
 * A user MUST be able to revoke delegated permissions.
-* Announcements from a delegate MUST be able to be verify which delegate made the specific announcement.
+* Announcements from a delegate MUST be able to be verify which delegate made the specific Announcement.
 * Delegation revocation MUST NOT be retroactive.
 
 ## Related Operations

--- a/pages/DSNP/Types/Broadcast.md
+++ b/pages/DSNP/Types/Broadcast.md
@@ -8,7 +8,7 @@ A Broadcast Announcement is a way to send a public message to everyone.
 | ----- | ----------- | --------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`2`) | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
 | contentHash | multihash-encoded hash of content stored at URL | variable length byte array | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
-| fromId | id of the user creating the announcement | 64-bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
+| fromId | id of the user creating the Announcement | 64-bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
 | url | content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
 
 ## Field Requirements

--- a/pages/DSNP/Types/Profile.md
+++ b/pages/DSNP/Types/Profile.md
@@ -5,12 +5,12 @@ The reference content *MUST be of profile type*.
 
 ## Fields
 
-| Field | Description | Serialization | Parquet Type | Bloom Filter |
-| ----- | ----------- | ------------- | ------------ | ------------ |
-| announcementType | Announcement Type Enum (`5`) | [decimal](../Serializations.md#decimal) | `INT32` | no |
-| contentHash | multihash-encoded hash of content stored at URL | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
-| fromId | id of the user creating the Announcement | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
-| url | profile content URL | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
+| Field | Description | Data Type | Serialization | Parquet Type | Bloom Filter |
+| ----- | ----------- | --------- | ------------- | ------------ | ------------ |
+| announcementType | Announcement Type Enum (`5`) | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
+| contentHash | multihash-encoded hash of content stored at URL | variable length byte array | [hexadecimal](../Serializations.md#hexadecimal) | `BYTE_ARRAY` | YES
+| fromId | id of the user creating the Announcement | 64-bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES
+| url | profile content URL | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no
 
 ## Field Requirements
 

--- a/pages/DSNP/Types/PublicKey.md
+++ b/pages/DSNP/Types/PublicKey.md
@@ -2,7 +2,7 @@
 
 A Public Key Announcement is a way to note a new or updated cryptographic key that can be used in DSNP to secure and verify the authenticity of communications.
 
-A Public Key Announcement should be treated as updating an existing key if the `fromId`, `keyType`, `keyId` and `publicKey` fields of the new  announcement match those of a previous announcement.
+A Public Key Announcement should be treated as updating an existing key if the `fromId`, `keyType`, `keyId` and `publicKey` fields of the new  Announcement match those of a previous Announcement.
 This may be used to announce that a particular key has been revoked or is no longer in use.
 
 The most recently published unrevoked key (if one exists) for a given key type should be treated as the active key of that key type.
@@ -16,7 +16,7 @@ Any data previously generated through use of the key that is after such a backda
 | Field | Description | Data Type | Serialization | Parquet Type | Bloom Filter |
 | ----- | ----------- | --------- | ------------- | ------------ | ------------ |
 | announcementType | Announcement Type Enum (`7`) | enum | [decimal](../Serializations.md#decimal) | `INT32` | no |
-| fromId | id of the user creating the announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES |
+| fromId | id of the user creating the Announcement | 64 bit unsigned integer | [decimal](../Serializations.md#decimal) | `UINT_64` | YES |
 | keyType | Key Type Enum | enum | [decimal](../Serializations.md#decimal)  |`INT32` | YES |
 | keyId | user-assigned identifier | 64 bit unsigned integer | [decimal](../Serializations.md#decimal)  |`UINT_64` | no |
 | publicKey | public key in multikey format | UTF-8 | [UTF-8](https://datatracker.ietf.org/doc/html/rfc3629) | `UTF8` | no

--- a/pages/DSNP/UserData.md
+++ b/pages/DSNP/UserData.md
@@ -89,10 +89,10 @@ The following example illustrates the input to the Replace User Data Operation c
 The private connection's PRId is added to the private connection PRId list, but it remains a single chunk.
 
 ```
-{ 
+{
   "publicFollows": {
     "version": "1.2",
-    "chunks": [ 
+    "chunks": [
       {
         "etag": string                             // unchanged chunk
       },
@@ -132,7 +132,7 @@ To ensure that the deleted chunk was up to date, the deleted chunk should still 
 ```
   "publicFollows": {
     "version": "1.2",
-    "chunks": [ 
+    "chunks": [
       {
         "etag": string                     // unchanged chunk
       },
@@ -170,10 +170,10 @@ _The JSON schema and encoding used is provided for illustration only and impleme
 The following example illustrates the output of a Get User Data Operation invocation requesting data for `publicFollows`, `privateConnections`, and `privateConnectionPRIds`:
 
 ```
-{ 
+{
   "publicFollows": {
     "version": "1.2",
-    "chunks": [ 
+    "chunks": [
       {
         "data": base64_string,
         "etag": string


### PR DESCRIPTION
Problem
=======

Some small formatting and standardization. No spec changes.

Fixes
--------

- Profile Announcement was missing the `Data Type` column
- Various places did not use uppercase Announcement
- Whitespace fixes