### PR TITLE
DIP-253 Add actor specification to Activity Content [DRAFT FOR DISCUSSION]

### DIFF
--- a/.spellcheckerdict.txt
+++ b/.spellcheckerdict.txt
@@ -65,6 +65,7 @@ PNG
 Polkadot
 Poly1305
 pre-configured
+Prerelease
 PRId([ABs])?
 publicKey
 repo

--- a/pages/ActivityContent/Overview.md
+++ b/pages/ActivityContent/Overview.md
@@ -1,5 +1,5 @@
 # Activity Content Specification
-__Version 1.2.0__
+__Version pre-1.2.1__
 
 Content references shared via the DSNP consist of URLs pointing to documents containing Activity Streams JSON objects.
 For the purposes of the DSNP, restrictions are placed on the [Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) specification.
@@ -46,8 +46,10 @@ URLs in DSNP-compatible Activity Content MUST use one of the following URL schem
 | [LibertyDSNP/activity-content-swift](https://github.com/LibertyDSNP/activity-content-swift) | Swift |
 
 <!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]`
-## Prerelease Changelog
 --->
+## Prerelease Changelog 
+
+[DIP-253](https://github.com/LibertyDSNP/spec/issues/253)
 
 ## Releases
 

--- a/pages/ActivityContent/Types/Note.md
+++ b/pages/ActivityContent/Types/Note.md
@@ -6,6 +6,7 @@
 | --- | --- | --- | --- | --- |
 | `@context` | [Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/#jsonld) | YES | JSON-LD @context | MUST be set to `https://www.w3.org/ns/activitystreams` |
 | `type` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-type) | YES | Identifies the type of the object | MUST be set to `Note` |
+| `actor` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-actor) | no | May be used to identify the DSNP User who originated the activity | Use [DSNP User URI](../DSNP/Identifiers.md#dsnp-user-uri) |
 | `content` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-content) | YES | Text content of the note |  |
 | `mediaType` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-mediatype) | YES | MIME type for the `content` field | MUST be set to a [supported MIME type](#supported-content-mime-types) |
 | `published` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-published) | YES | The time of publishing | MUST be [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) |
@@ -26,6 +27,7 @@
 {
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Note",
+  "actor": "dsnp://1727293022", 
   "content": "Hello world!",
   "mediaType": "text/plain",
   "published": "1970-01-01T00:00:00+00:00"
@@ -36,6 +38,7 @@
 {
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Note",
+  "actor": "dsnp://1727293022", 
   "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
   "mediaType": "text/plain",
   "summary": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",

--- a/pages/ActivityContent/Types/Profile.md
+++ b/pages/ActivityContent/Types/Profile.md
@@ -9,6 +9,7 @@ Profiles are used to provide additional user information display.
 | --- | --- | --- | --- | --- |
 | `@context` | [Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/#jsonld) | YES | JSON-LD @context | MUST be set to `https://www.w3.org/ns/activitystreams` |
 | `type` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-type) | YES | Identifies the type of the object | MUST be set to `Profile` |
+| `actor` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-actor) | no | May be used to identify the DSNP User who originated the activity | Use [DSNP User URI](../DSNP/Identifiers.md#dsnp-user-uri) |
 | `name` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-name) | no | The display name for the profile |  |
 | `icon` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-icon) | no | An array of avatars of the profile | MUST follow [Image Link Type](../Associated/Attachments.md#image-link) |
 | `summary` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-summary) | no | Used as a plain text biography of the profile |  |
@@ -22,6 +23,7 @@ Profiles are used to provide additional user information display.
 {
   "@context": "https://www.w3.org/ns/activitystreams",
   "type": "Profile",
+  "actor": "dsnp://1727293022", 
   "name": "John Doe",
   "summary": "John Doe is actually a small kitten. See pfp.",
   "icon": [

--- a/pages/DSNP/Announcements.md
+++ b/pages/DSNP/Announcements.md
@@ -35,6 +35,12 @@ When readers retrieve content referenced in an Announcement, they can validate t
 
 DSNP Announcements encode content hashes using the [multihash](https://github.com/multiformats/multihash) specification.
 
+## External Content Validation
+
+There is no guarantee that external documents will be syntactically or semantically valid.
+Readers should determine whether documents are well formed and implement appropriate error checking based on the expected file format.
+Where Activity Content is referenced, if the external object contains the optional `actor` field, and this field's value is a [DSNP User URI](Identifiers.md#dsnp-user-uri), readers MUST ensure that the DSNP User given matches the `senderId` of the referring Announcement.
+
 ### Supported Hashing Algorithms
 
 | Algorithm | Multihash Name | Leading bytes (as [varint](https://github.com/multiformats/unsigned-varint)) | Reference | DSNP Version Added |

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -1,5 +1,5 @@
 # DSNP Specification
-__Version 1.2.0__
+__Version pre-1.2.1__
 
 DSNP (Decentralized Social Networking Protocol) is a social networking protocol designed to run on a blockchain.
 It specifies a set of social primitives along with requirements for interoperability.
@@ -30,8 +30,10 @@ Compliant DSNP system specifications MUST document how each of the required DSNP
 A compliant specification MUST specify a mapping from its system-specific state change data (for example, the events emitted by a blockchain) to the DSNP State Change Records that data represents.
 
 <!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]`
-## Prerelease Changelog
 --->
+## Prerelease Changelog 
+
+[DIP-253](https://github.com/LibertyDSNP/spec/issues/253)
 
 ## Releases
 


### PR DESCRIPTION
Problem
=======
In the current spec it is possible for a user to announce (Broadcast, Reply, Profile) an Activity Content document that another user created and thereby claim it as their own. We have content authentication (contents of URL must match the hash) but not content provenance (user who claims to have originated the content must match the sender of the Announcement).

Link to GitHub Issue(s): https://github.com/LibertyDSNP/spec/issues/253 has further background.

Solution
========
We include the `actor` key (loosely defined in the Activity Content 2.0 specification) in the DSNP Activity Content specification, and define it as representing a DSNP User if it contains a DSNP User URI. By denormalizing in this way we enable readers to verify the linkage between `senderId` and `actor`.

Change summary:
---------------
- [ ] Updated Spec Versions (pre-1.2.1) for Activity Content and DSNP specs.
- [ ] Added `actor` to Note and Profile Activity Content objects
- [ ] Added info on the Announcements page describing the trust semantics of Activity Content

Steps to Verify:
----------------
1. Generate and view spec site.