### PR TITLE
Mainnet Frequency Schema Ids

### DIFF
--- a/pages/Frequency/Overview.md
+++ b/pages/Frequency/Overview.md
@@ -27,10 +27,10 @@ Official schemas may be found in [GitHub](https://github.com/LibertyDSNP/schemas
 | [Reaction](./Publishing.md) | 4 | 4 |
 | [Profile](./Publishing.md) | 6 | 5 |
 | [Update](./Publishing.md) | 5 | 6 |
-| [Public Key](./Publishing.md) | TBD | 18 |
-| [Public Follows](./UserData.md) | TBD | 13 |
-| [Private Follows](./UserData.md) | TBD | 14 |
-| [Private Connections](./UserData.md) | TBD | 15 |
+| [Public Key](./Publishing.md) | 7 | 18 |
+| [Public Follows](./UserData.md) | 8 | 13 |
+| [Private Follows](./UserData.md) | 9 | 14 |
+| [Private Connections](./UserData.md) | 10 | 15 |
 
 <!--
 ### Obsolete

--- a/pages/Frequency/Overview.md
+++ b/pages/Frequency/Overview.md
@@ -50,4 +50,4 @@ Official schemas may be found in [GitHub](https://github.com/LibertyDSNP/schemas
 
 | Last Update Date | Frequency Release | DSNP Version |
 | --- | --- | --- |
-| 2023-04-19 | 1.5.2+ | 1.2.0 |
+| 2023-07-17 | 1.5.2+ | 1.2.0 |

--- a/pages/Frequency/UserData.md
+++ b/pages/Frequency/UserData.md
@@ -8,9 +8,9 @@ On Frequency, User Data and select Announcements are mapped to Schemas which use
 
 | User Data Set | Schema Id Mainnet | Schema Id Rococo | Frequency Model Type | Frequency Payload Location | Settings |
 | --- | --- | --- | --- | --- | --- |
-| [Public Follows](../DSNP/Graph.md#public-follows) | TBD | 13 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
-| [Private Follows](../DSNP/Graph.md#private-follows) | TBD | 14 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
-| [Private Connections](../DSNP/Graph.md#private-connections) | TBD | 15 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
+| [Public Follows](../DSNP/Graph.md#public-follows) | 8 | 13 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
+| [Private Follows](../DSNP/Graph.md#private-follows) | 9 | 14 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
+| [Private Connections](../DSNP/Graph.md#private-connections) | 10 | 15 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
 
 [Pseudonymous Relationship Identifiers](./../DSNP/Graph.md#pseudonymous-relationship-identifiers) (PRIds) are stored along side Private Connections in the same Stateful Storage page.
 
@@ -20,7 +20,7 @@ Source code for each schema is located in the [LibertyDSNP/schemas](https://gith
 
 | Announcement | Schema Id Mainnet | Schema Id Rococo | Frequency Model Type | Frequency Payload Location | Settings |
 | --- | --- | --- | --- | --- | --- |
-| [Public Key](../DSNP/Types/PublicKey.md) | TBD | 7 (_v1.3.0+_) | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Itemized`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Itemized) | [Append Only](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.AppendOnly), [Signature Required](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.SignatureRequired) |
+| [Public Key](../DSNP/Types/PublicKey.md) | 7 | 7 (_v1.3.0+_) | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Itemized`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Itemized) | [Append Only](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.AppendOnly), [Signature Required](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.SignatureRequired) |
 
 
 ## Read Operation Mapping


### PR DESCRIPTION
Problem
=======
Updated Frequency System Spec for the newly published Graph Schema Ids

This can be confirmed by running `DEPLOY_SCHEMA_ENDPOINT_URL="wss://0.rpc.frequency.xyz" npm run read` from https://github.com/LibertyDSNP/schemas/