### PR TITLE
Fix a nonstandard example DSNP URI

### DIFF
--- a/pages/ActivityContent/Associated/Tag.md
+++ b/pages/ActivityContent/Associated/Tag.md
@@ -48,7 +48,7 @@
     {
       "name": "@sally",
       "type": "Mention",
-      "id": "dsnp://0x12345678"
+      "id": "dsnp://12345678"
     }
   ],
   "published": "1970-01-01T00:00:00+00:00"


### PR DESCRIPTION
Old: `dsnp://0x12345678`
New: `dsnp://12345678`

I checked that this was not being repeated anywhere else in the spec.