### PR TITLE
DIP-260 Remove outdated entries from the glossary, and clarify others

### DIFF
--- a/pages/Reference/Glossary.md
+++ b/pages/Reference/Glossary.md
@@ -1,16 +1,10 @@
 # Glossary
 
-* **Activity Content** - The linked content connected to an "Announcement"
-* **Announcement** - An item of data, typically an image or note, posted to the blockchain via a "Batch Publication"
-* **Bad actor** - A user intentionally using the application for bad-faith or illegal purposes
-* **Batch Publication** - A collection of Announcements
-* **Bot** - An automated account, sometimes malicious but often providing some service ("Hey Alexa, what's the weather?")
-* **Consumer** - Someone who reads content from social media
-* **Contract address** - The unique number associated with a smart contract posted on the blockchain
-* **Hash Collision** - The vanishingly unlikely possibility of a hash providing the same output for two different inputs
-* **Hash function** - A cryptographic function whose output is effectively unique for any given input without any information from the input being accessible in the output
-* **Hash** - A string of characters generated from a hash function, see "Hash function"
-* **Identity Contract** - The smart contract used to store a user's delegated public addresses and permissions, see "Contract address"
-* **Publisher** - The contract that posts new content from a publisher to the blockchain through batch publications
-* **Store** - A means of keeping messages or data for an extended period of time
-* **User** - A human using our application. [See article for an exception](https://time.com/4008832/17-dogs-to-follow-on-instagram/)
+* **Activity Content** - User-generated social networking content in a JSON format defined by the Activity Streams 2.0 specification with DSNP extensions. Some DSNP Announcements contain the URL and hash for an Activity Content document.
+* **Announcement** - Content, or references to content, that communicate user activity to the network.
+* **Application** - A computer program that helps a User interact with a DSNP system
+* **Batch Publication** - A collection of Announcements bundled together into a single file using the Parquet format
+* **Consumer** - An application or user who reads content from a DSNP system
+* **DSNP System** - A consensus system (and its surrounding services) that enables DSNP operations and generates DSNP state change records
+* **Hash** - A string of bytes generated from a hash function, a cryptographic function whose output is effectively unique for any given input without any information from the input being accessible in the output
+* **User** - A human using a DSNP application. [See article for an exception](https://time.com/4008832/17-dogs-to-follow-on-instagram/)


### PR DESCRIPTION
Problem
=======
Glossary contains out-of-date terminology no longer associated with the spec.

Link to GitHub Issue(s): #260 

Solution
========
Removed items that clearly no longer applied.
Edited a few others.

The brevity of the page after these changes arouses suspicion that we may not benefit much from having a glossary, but perhaps we will find items to add at a later time.

Change summary:
---------------
- Changes to Glossary page only. I do not believe this warrants a spec versioning bump.