### PR TITLE
Update schema ids for Frequency Testnet Paseo

### DIFF
--- a/.spellcheckerdict.txt
+++ b/.spellcheckerdict.txt
@@ -61,6 +61,7 @@ objectId
 OGG
 Parachain
 parseable
+Paseo
 PNG
 Polkadot
 Poly1305
@@ -84,6 +85,8 @@ SVG
 targetAnnouncementType
 targetContentHash
 TBD
+[Tt]estnet
+[0-9]*[Tt]estnet
 [Tt]ombston(ed|ing)
 UINT_8
 uncompress

--- a/pages/Frequency/Overview.md
+++ b/pages/Frequency/Overview.md
@@ -19,25 +19,25 @@ Official schemas may be found in [GitHub](https://github.com/LibertyDSNP/schemas
 
 <!-- These ids are duplicated here for quick reference. -->
 
-| Name | Schema Id Mainnet | Schema Id Rococo |
-| --- | --- | --- |
-| [Tombstone](./Publishing.md) | 1 | 1 |
-| [Broadcast](./Publishing.md) | 2 | 2 |
-| [Reply](./Publishing.md) | 3 | 3 |
-| [Reaction](./Publishing.md) | 4 | 4 |
-| [Profile](./Publishing.md) | 6 | 5 |
-| [Update](./Publishing.md) | 5 | 6 |
-| [Public Key](./Publishing.md) | 7 | 18 |
-| [Public Follows](./UserData.md) | 8 | 13 |
-| [Private Follows](./UserData.md) | 9 | 14 |
-| [Private Connections](./UserData.md) | 10 | 15 |
+| Name | Schema Id Mainnet | Schema Id Testnet (Paseo) | Schema Id Testnet (Rococo) |
+| --- | --- | --- | --- |
+| [Tombstone](./Publishing.md) | 1 | 1 | 1 |
+| [Broadcast](./Publishing.md) | 2 | 2 | 2 |
+| [Reply](./Publishing.md) | 3 | 3 | 3 |
+| [Reaction](./Publishing.md)| 4 | 4 | 4 |
+| [Profile](./Publishing.md) | 6 | 6 | 5 |
+| [Update](./Publishing.md)| 5 | 5 | 6 |
+| [Public Key](./Publishing.md)| 7 | 7 | 18 |
+| [Public Follows](./UserData.md)| 8 | 8 | 13 |
+| [Private Follows](./UserData.md) | 9 | 9 | 14 |
+| [Private Connections](./UserData.md) | 10 | 10 | 15 |
 
 <!--
 ### Obsolete
 
-| Name | Mainnet Block Obsoleted | Schema Id Mainnet | Schema Id Rococo |
-| --- | --- | --- | --- |
-| TBD | TBD | 0 | 0 |
+| Name | Mainnet Block Obsoleted | Schema Id Mainnet | Schema Id Testnet (Paseo) | Schema Id Testnet (Rococo) |
+| --- | --- | --- | --- | --- |
+| TBD | TBD | 0 | 0 | 0 |
 
 -->
 

--- a/pages/Frequency/Publishing.md
+++ b/pages/Frequency/Publishing.md
@@ -6,17 +6,17 @@ Frequency Stateful Storage is either direct Announcements from a particular user
 
 <!-- Links to https://libertydsnp.github.io/frequency should be updated with links to docs.frequency.xyz when able to be -->
 
-<!-- Update ./Overview.md if a Schema Id is updated  -->
+<!-- Update ./Overview.md if a Schema Id is updated -->
 
-| Announcement Type Enum | Announcement | Type | Schema Id Mainnet | Schema Id Rococo | Frequency Model Type | Frequency Payload Location |
-| --- | --- | --- | --- | --- | --- | --- |
-| 0 | [Tombstone](../DSNP/Types/Tombstone.md) | Batched | 1 | 1 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
-| 2 | [Broadcast](../DSNP/Types/Broadcast.md) | Batched | 2 | 2 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
-| 3 | [Reply](../DSNP/Types/Reply.md) | Batched | 3 | 3 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
-| 4 | [Reaction](../DSNP/Types/Reaction.md) | Batched | 4 | 4 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
-| 5 | [Profile](../DSNP/Types/Profile.md) | Batched | 6 | 5 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
-| 6 | [Update](../DSNP/Types/Update.md) | Batched | 5 | 6 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
-| 7 | [Public Key](../DSNP/Types/PublicKey.md) | [Stateful](./UserData.md#announcements) | TBD | 18 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Itemized`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Itemized) |
+| Enum | Announcement | Type | Deployed Schema Id | Frequency Model Type | Frequency Payload Location |
+| :--: | --- | --- | --- | --- | --- |
+| 0 | [Tombstone](../DSNP/Types/Tombstone.md) | Batched | Mainnet: 1<br />Testnet (Paseo): 1<br />Testnet (Rococo): 1 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
+| 2 | [Broadcast](../DSNP/Types/Broadcast.md) | Batched | Mainnet: 2<br />Testnet (Paseo): 2<br />Testnet (Rococo): 2 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
+| 3 | [Reply](../DSNP/Types/Reply.md) | Batched | Mainnet: 3<br />Testnet (Paseo): 3<br />Testnet (Rococo): 3 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
+| 4 | [Reaction](../DSNP/Types/Reaction.md) | Batched | Mainnet: 4<br />Testnet (Paseo): 4<br />Testnet (Rococo): 4 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
+| 5 | [Profile](../DSNP/Types/Profile.md) | Batched | Mainnet: 6<br />Testnet (Paseo): 6<br />Testnet (Rococo): 5 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
+| 6 | [Update](../DSNP/Types/Update.md) | Batched | Mainnet: 5<br />Testnet (Paseo): 5<br />Testnet (Rococo): 6 | [`Parquet`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.Parquet) | [`IPFS`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.IPFS) |
+| 7 | [Public Key](../DSNP/Types/PublicKey.md) | [Stateful](./UserData.md#announcements) | Mainnet: 7<br />Testnet (Paseo): 7<br />Testnet (Rococo): 18 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Itemized`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Itemized) |
 
 Source code for each schema is located in the [LibertyDSNP/schemas](https://github.com/LibertyDSNP/schemas) repository.
 

--- a/pages/Frequency/UserData.md
+++ b/pages/Frequency/UserData.md
@@ -4,13 +4,13 @@ On Frequency, User Data and select Announcements are mapped to Schemas which use
 
 ## User Data Sets
 
-<!-- Update ./Overview.md if a Schema Id is updated  -->
+<!-- Update ./Overview.md if a Schema Id is updated -->
 
-| User Data Set | Schema Id Mainnet | Schema Id Rococo | Frequency Model Type | Frequency Payload Location | Settings |
-| --- | --- | --- | --- | --- | --- |
-| [Public Follows](../DSNP/Graph.md#public-follows) | 8 | 13 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
-| [Private Follows](../DSNP/Graph.md#private-follows) | 9 | 14 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
-| [Private Connections](../DSNP/Graph.md#private-connections) | 10 | 15 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
+| User Data Set | Deployed Schema Ids | Frequency Model Type | Frequency Payload Location | Settings |
+| --- | --- | --- | --- | --- |
+| [Public Follows](../DSNP/Graph.md#public-follows) | Mainnet: 8<br />Testnet (Paseo): 8<br />Testnet (Rococo): 13 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
+| [Private Follows](../DSNP/Graph.md#private-follows) | Mainnet: 9<br />Testnet (Paseo): 9<br />Testnet (Rococo): 14 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
+| [Private Connections](../DSNP/Graph.md#private-connections) | Mainnet: 10<br />Testnet (Paseo): 10<br />Testnet (Rococo): 15 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Paginated`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Paginated) | None |
 
 [Pseudonymous Relationship Identifiers](./../DSNP/Graph.md#pseudonymous-relationship-identifiers) (PRIds) are stored along side Private Connections in the same Stateful Storage page.
 
@@ -18,10 +18,9 @@ Source code for each schema is located in the [LibertyDSNP/schemas](https://gith
 
 ## Announcements
 
-| Announcement | Schema Id Mainnet | Schema Id Rococo | Frequency Model Type | Frequency Payload Location | Settings |
-| --- | --- | --- | --- | --- | --- |
-| [Public Key](../DSNP/Types/PublicKey.md) | 7 | 7 (_v1.3.0+_) | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Itemized`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Itemized) | [Append Only](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.AppendOnly), [Signature Required](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.SignatureRequired) |
-
+| Announcement | Deployed Schema Ids | Frequency Model Type | Frequency Payload Location | Settings |
+| --- | --- | --- | --- | --- |
+| [Public Key](../DSNP/Types/PublicKey.md) | Mainnet: 7<br />Testnet (Paseo): 7<br />Testnet (Rococo): 7 | [`AvroBinary`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.ModelType.html#variant.AvroBinary) | [`Itemized`](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.PayloadLocation.html#variant.Itemized) | [Append Only](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.AppendOnly), [Signature Required](https://libertydsnp.github.io/frequency/common_primitives/schema/enum.SchemaSetting.html#variant.SignatureRequired) |
 
 ## Read Operation Mapping
 


### PR DESCRIPTION
Problem
=======
The new Frequency Paseo Testnet is up and has schemas deployed!

Also added missing Mainnet schema that was set to TBD.

```
 {
  "0x203c6838fc78ea3660a2f298a58d859519c72a5efdc0f194abd6f0d5ce1838e0": {
    "tombstone": {
      "1.2": 1
    },
    "broadcast": {
      "1.2": 2
    },
    "reply": {
      "1.2": 3
    },
    "reaction": {
      "1.1": 4
    },
    "profile": {
      "1.2": 5
    },
    "update": {
      "1.2": 6
    },
    "public-key-key-agreement": {
      "1.2": 7
    },
    "public-follows": {
      "1.2": 8
    },
    "private-follows": {
      "1.2": 9
    },
    "private-connections": {
      "1.2": 10
    },
    "public-key-assertion-method": {
      "1.3": 11
    }
  }
}
```
