### PR TITLE
DIP-287 Add inReplyTo to Reply Notes

### DIFF
--- a/pages/ActivityContent/Overview.md
+++ b/pages/ActivityContent/Overview.md
@@ -1,5 +1,5 @@
 # Activity Content Specification
-__Version 1.3.0__
+__Version pre-1.4.0__
 
 Content references shared via the DSNP consist of URLs pointing to documents containing Activity Streams JSON objects.
 For the purposes of the DSNP, restrictions are placed on the [Activity Streams 2.0](https://www.w3.org/TR/activitystreams-core/) specification.
@@ -45,11 +45,11 @@ URLs in DSNP-compatible Activity Content MUST use one of the following URL schem
 | [LibertyDSNP/activity-content-java](https://github.com/LibertyDSNP/activity-content-java) | Java/Kotlin |
 | [LibertyDSNP/activity-content-swift](https://github.com/LibertyDSNP/activity-content-swift) | Swift |
 
-<!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]`
+<!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]` --->
 ## Prerelease Changelog
 
-- [DIP-xxx](https://github.com/LibertyDSNP/spec/issues/xxx) Name of Feature
---->
+- [DIP-287](https://github.com/LibertyDSNP/spec/issues/287) DSNP Content URI Specificity
+
 
 ## Releases
 

--- a/pages/ActivityContent/Types/Note.md
+++ b/pages/ActivityContent/Types/Note.md
@@ -13,6 +13,7 @@
 | `attachment` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-attachment) | no | Array of attached links or media | MUST be one of the [Supported Attachments](../Associated/Attachments.md) |
 | `tag` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-tag) | no | Array of tags/mentions | MUST follow [Tag Type](../Associated/Tag.md) |
 | `location` | [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-location) | no | For location | MUST follow [Location Type](../Associated/Location.md) |
+| `inReplyTo` |  [Activity Vocabulary 2.0](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-inreplyto) | no | Identifies the content being replied to | MUST be a [DSNP Content URI](../../DSNP/Identifiers.md#dsnp-content-uri) |
 
 ## Supported Content MIME Types
 
@@ -22,6 +23,7 @@
 
 ## Examples
 
+### Basic Note
 ```json
 {
   "@context": "https://www.w3.org/ns/activitystreams",
@@ -31,6 +33,20 @@
   "published": "1970-01-01T00:00:00+00:00"
 }
 ```
+
+### Note Replying to a DSNP Note
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "Note",
+  "inReplyTo": "dsnp://123456/bdyqdua4t4pxgy37mdmjyqv3dejp5betyqsznimpneyujsur23yubzna",
+  "content": "Hello world!",
+  "mediaType": "text/plain",
+  "published": "1970-01-01T00:00:00+00:00"
+}
+```
+
+### Note with a Link Attachment
 
 ```json
 {

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -1,5 +1,5 @@
 # DSNP Specification
-__Version 1.3.0__
+__Version pre-1.4.0__
 
 DSNP (Decentralized Social Networking Protocol) is a social networking protocol designed to run on a blockchain.
 It specifies a set of social primitives along with requirements for interoperability.
@@ -29,11 +29,10 @@ Compliant DSNP system specifications MUST document how each of the required DSNP
 
 A compliant specification MUST specify a mapping from its system-specific state change data (for example, the events emitted by a blockchain) to the DSNP State Change Records that data represents.
 
-<!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]`
+<!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]` --->
 ## Prerelease Changelog
 
-- [DIP-xxx](https://github.com/LibertyDSNP/spec/issues/xxx) Name of Feature
---->
+- [DIP-287](https://github.com/LibertyDSNP/spec/issues/287) DSNP Content URI Specificity
 
 ## Releases
 

--- a/pages/DSNP/Overview.md
+++ b/pages/DSNP/Overview.md
@@ -31,6 +31,7 @@ A compliant specification MUST specify a mapping from its system-specific state 
 
 <!--- Uncomment for pre-release changes and prefix the version with `pre-[next version]` --->
 ## Prerelease Changelog
+<!--- [DIP-xxx](https://github.com/LibertyDSNP/spec/issues/xxx) Name of Feature --->
 
 - [DIP-287](https://github.com/LibertyDSNP/spec/issues/287) DSNP Content URI Specificity
 


### PR DESCRIPTION
Problem
=======
The current lack of specificity in Reply Note content could lead to certain corner cases that may be difficult or nondeterministic for applications to handle.

Link to GitHub Issue(s): #287 

Solution
========
Add requirement for `inReplyTo` with DSNP Content URI in Activity Content Note document.
This ensures that a given Reply Note can only ever be in reply to a single parent in its thread.

Change summary:
---------------
- [x] Updated Spec Versions (pre-1.4.0 for Activity Content and DSNP)
- [x] Changes to Note specification
- [x] Additional examples

Steps to Verify:
----------------
1. Documentation-only change. Follow normal documentation generation steps.
