### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -1,4 +1,6 @@
 name: Verify PR
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/LibertyDSNP/spec/security/code-scanning/1](https://github.com/LibertyDSNP/spec/security/code-scanning/1)

To fix the problem, explicitly set permissions for the job or workflow and grant only the minimal required access. Since this workflow only checks out code, installs dependencies, runs linter and spellchecker, and builds documentation (without performing any write operations to the repository), it likely only needs `contents: read` for the token. The safest, most minimal correct fix is to add a `permissions:` block with `contents: read` at the workflow ROOT (applies to all jobs, the recommended pattern). To implement, insert the `permissions:` block after the `name:` key, before `on:`. No other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
